### PR TITLE
LFPART compute route

### DIFF
--- a/sspi_flask_app/api/core/compute.py
+++ b/sspi_flask_app/api/core/compute.py
@@ -308,6 +308,21 @@ def compute_senior():
     print(incomplete_observations)
     return parse_json(clean_document_list)
 
+#################################
+## Category: WORKER ENGAGEMENT ##
+#################################
+
+@compute_bp.route("/LFPART", methods=['GET'])
+@login_required
+def compute_lfpart():
+    if not sspi_raw_api_data.fetch_raw_data("LFPART"):
+        return redirect(url_for("collect_bp.SENIOR"))
+    raw_data = sspi_raw_api_data.fetch_raw_data("LFPART")
+    # extractAllSeries(raw_data[0]['Raw'])
+    metadata = raw_data[0]['Metadata']
+    metadata_soup = bs.BeautifulSoup(metadata, "lxml")
+    print(raw_data[0].keys())
+    return jsonify([[tag.get("value"), tag.get_text()] for tag in metadata_soup.find_all("code")])
 
 @compute_bp.route("/PRISON", methods=['GET'])
 @login_required

--- a/sspi_flask_app/api/core/compute.py
+++ b/sspi_flask_app/api/core/compute.py
@@ -316,13 +316,12 @@ def compute_senior():
 @login_required
 def compute_lfpart():
     if not sspi_raw_api_data.fetch_raw_data("LFPART"):
-        return redirect(url_for("collect_bp.SENIOR"))
+        return redirect(url_for("collect_bp.LFPART"))
     raw_data = sspi_raw_api_data.fetch_raw_data("LFPART")
-    # extractAllSeries(raw_data[0]['Raw'])
-    metadata = raw_data[0]['Metadata']
-    metadata_soup = bs.BeautifulSoup(metadata, "lxml")
-    print(raw_data[0].keys())
-    return jsonify([[tag.get("value"), tag.get_text()] for tag in metadata_soup.find_all("code")])
+    raw_data_soup = bs.BeautifulSoup(raw_data[0]['Raw'], "lxml")
+    return jsonify(raw_data[0]['Raw'])
+    # print(raw_data_soup.find_all('generic:series'))
+    # return None
 
 @compute_bp.route("/PRISON", methods=['GET'])
 @login_required

--- a/sspi_flask_app/api/datasource/ilo.py
+++ b/sspi_flask_app/api/datasource/ilo.py
@@ -16,25 +16,21 @@ def extractAllSeriesILO(ilo_sdmxml):
     series = soup.find_all('generic:series')
     return series
 
-def filterSeriesListILO(series_list, filterVAR, ILOIndicatorCode, IndicatorCode):
+def filterSeriesListlfpart(series_list):
     # Return a list of series that match the filterVAR variable name
     document_list = []
     for i, series in enumerate(series_list):
         series_key, series_attributes = series.find("generic:serieskey"), series.find("generic:attributes")
-        VAR = series_key.find("generic:value", attrs={"concept": "VAR"}).get("value")
-        if VAR != filterVAR:
+        VAR = series_key.find("generic:value", attrs={"id": "MEASURE"}).get("value")
+        sex = series_key.find("generic:value", attrs={"id":"SEX"}).get("value")
+        if VAR != "EAP_DWAP_RT" or sex !="SEX_T":
             continue
-        id_info = {
-            "CountryCode": series_key.find("generic:value", attrs={"concept": ""}).get("value"),
-            "VariableCodeOECD": VAR,
-            "IndicatorCodeOECD": ILOIndicatorCode,
-            "Source": "ILO",
-            "IndicatorCode": IndicatorCode,
-            "Unit": series_attributes.find("value", attrs={"concept": "UNIT"}).get("value"),
-            "Pollutant": series_key.find("value", attrs={"concept": "POL"}).get("value"),
+        doc = {
+            "CountryCode": series_key.find("generic:value", attrs={"id": "REF_AREA"}).get("value"),
+            "IndicatorCode": "LFPART",
+            "Unit": series_attributes.find("generic:value", attrs={"id": "UNIT_MEASURE"}).get("value"),
+            "Year": series.find("generic:obs").find("generic:obsdimension", attrs={"id": "TIME_PERIOD"}).get("value"),
+            "Value": series.find("generic:obs").find("generic:obsvalue").get("value")
         }
-        new_documents = [{"Year": obs.find("time").text, "Value":obs.find("obsvalue").get("value")} for obs in series.find_all("obs")]
-        for doc in new_documents:
-            doc.update(id_info)
-        document_list.extend(new_documents)
+        document_list.append(doc)
     return document_list

--- a/sspi_flask_app/api/datasource/ilo.py
+++ b/sspi_flask_app/api/datasource/ilo.py
@@ -1,5 +1,6 @@
 import requests
 from ... import sspi_raw_api_data
+import bs4 as bs
 
 def collectILOData(ILOIndicatorCode, IndicatorCode, QueryParams="....", **kwargs):
     yield "Sending Data Request to ILO API\n"
@@ -9,3 +10,31 @@ def collectILOData(ILOIndicatorCode, IndicatorCode, QueryParams="....", **kwargs
     yield "Data Received from ILO API.  Storing Data in SSPI Raw Data\n"
     count = sspi_raw_api_data.raw_insert_one(observation, IndicatorCode, **kwargs)
     yield f"Inserted {count} observations into the database."
+
+def extractAllSeriesILO(ilo_sdmxml):
+    soup = bs.BeautifulSoup(ilo_sdmxml, 'lxml')
+    series = soup.find_all('generic:series')
+    return series
+
+def filterSeriesListILO(series_list, filterVAR, ILOIndicatorCode, IndicatorCode):
+    # Return a list of series that match the filterVAR variable name
+    document_list = []
+    for i, series in enumerate(series_list):
+        series_key, series_attributes = series.find("generic:serieskey"), series.find("generic:attributes")
+        VAR = series_key.find("generic:value", attrs={"concept": "VAR"}).get("value")
+        if VAR != filterVAR:
+            continue
+        id_info = {
+            "CountryCode": series_key.find("generic:value", attrs={"concept": ""}).get("value"),
+            "VariableCodeOECD": VAR,
+            "IndicatorCodeOECD": ILOIndicatorCode,
+            "Source": "ILO",
+            "IndicatorCode": IndicatorCode,
+            "Unit": series_attributes.find("value", attrs={"concept": "UNIT"}).get("value"),
+            "Pollutant": series_key.find("value", attrs={"concept": "POL"}).get("value"),
+        }
+        new_documents = [{"Year": obs.find("time").text, "Value":obs.find("obsvalue").get("value")} for obs in series.find_all("obs")]
+        for doc in new_documents:
+            doc.update(id_info)
+        document_list.extend(new_documents)
+    return document_list


### PR DESCRIPTION
XML format is different than OECD, each Series only has one associated value so getting long-formatted data is much easier + no intermediates