### PR TITLE
Bulk Data Hosting on Server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ htmlcov/
 **.ipynb_checkpoints
 snapshots/**/**.json
 profiler/**
+bulk

--- a/.gitignore
+++ b/.gitignore
@@ -85,4 +85,6 @@ htmlcov/
 **.ipynb_checkpoints
 snapshots/**/**.json
 profiler/**
-bulk
+bulk/SUS/LND/NITROG/*
+!bulk/SUS/LND/NITROG/replicate
+

--- a/bulk/SUS/LND/NITROG/replicate
+++ b/bulk/SUS/LND/NITROG/replicate
@@ -1,0 +1,7 @@
+#!/bin/bash
+source ~/.config/secrets/sspi.world
+curl --output $SSPI_DIR_ROOT_PATH/bulk/SUS/LND/NITROG/epi2024raw.zip https://epi.yale.edu/downloads/epi2024raw.zip
+curl --output $SSPI_DIR_ROOT_PATH/bulk/SUS/LND/NITROG/2024-epi-report.pdf https://epi.yale.edu/downloads/2024epireport.pdf
+curl --output $SSPI_DIR_ROOT_PATH/bulk/SUS/LND/NITROG/2024-epi-technical-appendix.pdf https://epi.yale.edu/downloads/2024-epi-technical-appendix.pdf
+unzip -d $SSPI_DIR_ROOT_PATH/bulk/SUS/LND/NITROG $SSPI_DIR_ROOT_PATH/bulk/SUS/LND/NITROG/epi2024raw.zip
+rm -rf $SSPI_DIR_ROOT_PATH/bulk/SUS/LND/NITROG/__MACOSX

--- a/sspi_flask_app/__init__.py
+++ b/sspi_flask_app/__init__.py
@@ -83,6 +83,7 @@ def init_app(Config):
         from .api.core.delete import delete_bp
         # from .api.core.download import download_bp
         from .api.core.finalize import finalize_bp
+        from .api.core.host import host_bp
         from .api.core.impute import impute_bp
         from .api.core.load import load_bp
         from .api.core.query import query_bp
@@ -100,6 +101,7 @@ def init_app(Config):
         api_bp.register_blueprint(delete_bp)
         # api_bp.register_blueprint(download_bp)
         api_bp.register_blueprint(finalize_bp)
+        api_bp.register_blueprint(host_bp)
         api_bp.register_blueprint(impute_bp)
         api_bp.register_blueprint(load_bp)
         api_bp.register_blueprint(query_bp)

--- a/sspi_flask_app/api/core/host.py
+++ b/sspi_flask_app/api/core/host.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, send_file
+from flask import Blueprint, send_file, current_app as app
 from flask_login import login_required
 import os
 
@@ -11,6 +11,7 @@ host_bp = Blueprint(
 
 
 @host_bp.route("/NITROG")
+@login_required
 def serve_nitrog():
     bulk_path = os.path.join(os.path.dirname(app.instance_path), "bulk")
     csv_filepath = os.path.join(bulk_path, "SUS/LND/NITROG/Raw/SNM_raw.csv")
@@ -18,5 +19,5 @@ def serve_nitrog():
         csv_filepath,
         mimetype="text/csv",
         as_attachment=True,
-        download_name="file.csv"  # Name for the downloaded file
+        download_name="NITROG-RAW-DATA.csv"  # Name for the downloaded file
     )

--- a/sspi_flask_app/api/core/host.py
+++ b/sspi_flask_app/api/core/host.py
@@ -1,0 +1,22 @@
+from flask import Blueprint, send_file
+from flask_login import login_required
+import os
+
+host_bp = Blueprint(
+    "host_bp", __name__,
+    template_folder="templates",
+    static_folder="static", 
+    url_prefix="/bulk"
+)
+
+
+@host_bp.route("/NITROG")
+def serve_nitrog():
+    bulk_path = os.path.join(os.path.dirname(app.instance_path), "bulk")
+    csv_filepath = os.path.join(bulk_path, "SUS/LND/NITROG/Raw/SNM_raw.csv")
+    return send_file(
+        csv_filepath,
+        mimetype="text/csv",
+        as_attachment=True,
+        download_name="file.csv"  # Name for the downloaded file
+    )


### PR DESCRIPTION
Not sure we're going to need to use this, but it serves as a backup for now to the new collect and compute routes pulling file data.
- **chore: Updated Gitignore to ignore the hosted version of local data.**
- **fix: Setup Version Control Only for Replication Script**
- **feat: Initialized Host Blueprint**
- **feat: Imported and Registered Blueprints**
