### PR TITLE
442 set fixed years 2000 to present for dynamic line

### DIFF
--- a/sspi_flask_app/api/core/finalize.py
+++ b/sspi_flask_app/api/core/finalize.py
@@ -23,6 +23,7 @@ import re
 import os
 import json
 import pycountry
+from datetime import datetime
 
 
 finalize_bp = Blueprint(
@@ -144,12 +145,8 @@ def finalize_sspi_dynamic_line_data():
             {"IndicatorCode": IndicatorCode},
             {"_id": 0}
         )
-        year_list = [int(o["Year"]) for o in data]
-        if len(year_list) == 0:
-            continue
-        print(IndicatorCode, len(year_list))
-        min_year = min(year_list)
-        max_year = max(year_list)
+        min_year = 2000
+        max_year = datetime.now().year
         label_list = list(range(min_year, max_year + 1))
         for observation in data:
             CountryCode = observation["CountryCode"]
@@ -164,7 +161,10 @@ def finalize_sspi_dynamic_line_data():
             values = [None] * len(label_list)
             data = [None] * len(label_list)
             for doc in document:
-                year_index = label_list.index(doc["Year"])
+                try:
+                    year_index = label_list.index(doc["Year"])
+                except ValueError:
+                    continue
                 years[year_index] = doc["Year"]
                 scores[year_index] = doc["Score"]
                 values[year_index] = doc["Value"]


### PR DESCRIPTION
- **physpc**
- **changes to main... sorry for working on main**
- **merged main**
- **all collects written**
- ***if we want to use sdg for education***
- **plotted cleaned enrollment data**
- **UIS collect implemented, testing**
- **wrote UIS clean**
- **enrpri and enrsec finsihed, started on pupil**
- **education so far**
- **style: Whitespace**
- **fix: Years Start at 2000 for all indicators**
