### PR TITLE
583 create datacoverage object

### DIFF
--- a/cli/cli.py
+++ b/cli/cli.py
@@ -1,6 +1,7 @@
 import click
 from cli.commands.collect import collect
 from cli.commands.compute import compute
+from cli.commands.coverage import coverage
 from cli.commands.delete import delete
 from cli.commands.extrapolate import extrapolate
 from cli.commands.interpolate import interpolate
@@ -22,6 +23,7 @@ def cli():
 
 cli.add_command(collect)
 cli.add_command(compute)
+cli.add_command(coverage)
 cli.add_command(delete)
 cli.add_command(extrapolate)
 cli.add_command(interpolate)

--- a/cli/commands/coverage.py
+++ b/cli/commands/coverage.py
@@ -4,11 +4,39 @@ from cli.utilities import echo_pretty
 import json
 
 
-@click.command(help="Compute data coverage")
+@click.group(invoke_without_command=True, help="Get data coverage information")
 @click.option("--remote", "-r", is_flag=True, help="Send the request to the remote server")
-def coverage(remote=False):
+@click.option("--group", "-g", type=str, help="CountryGroup (default: SSPI67)")
+@click.pass_context
+def coverage(ctx, remote=False, group="SSPI67"):
+    if ctx.invoked_subcommand is None:
+        connector = SSPIDatabaseConnector()
+        url = "/api/v1/utilities/coverage"
+        if group:
+            url += f"?CountryGroup={group}"
+        res = connector.call(url, remote=remote)
+        if res.status_code != 200:
+            raise click.ClickException(
+                f"Error! Compute Request Failed with Status Code {res.status_code}"
+            )
+            echo_pretty(res.header)
+            echo_pretty(res.text)
+        click.echo(json.dumps(res.json()))
+
+
+@coverage.command(help="Retrieve the list of indicators for which data coverage is complete")
+@click.option("--remote", "-r", is_flag=True, help="Send the request to the remote server")
+@click.option("--group", "-g", type=str, help="CountryGroup (default: SSPI67)")
+def complete(remote=False, group="SSPI67"):
+    """
+    Retrieve the list of indicators for which data coverage is complete.
+    :param remote: If True, send the request to the remote server.
+    :param group: The country group to check coverage for (default: SSPI67).
+    """
     connector = SSPIDatabaseConnector()
-    request_string = "/api/v1/utilities/coverage"
+    request_string = "/api/v1/utilities/coverage/complete"
+    if group:
+        request_string += f"?CountryGroup={group}"
     res = connector.call(request_string, remote=remote)
     if res.status_code != 200:
         raise click.ClickException(
@@ -17,3 +45,75 @@ def coverage(remote=False):
         echo_pretty(res.header)
         echo_pretty(res.text)
     click.echo(json.dumps(res.json()))
+
+
+@coverage.command(help="Retrieve the list of indicators for which data coverage is incomplete")
+@click.option("--remote", "-r", is_flag=True, help="Send the request to the remote server")
+@click.option("--group", "-g", type=str, help="CountryGroup (default: SSPI67)")
+def incomplete(remote=False, group="SSPI67"):
+    connector = SSPIDatabaseConnector()
+    request_string = "/api/v1/utilities/coverage/incomplete"
+    res = connector.call(request_string, remote=remote)
+    if res.status_code != 200:
+        raise click.ClickException(
+            f"Error! Compute Request Failed with Status Code {res.status_code}"
+        )
+        echo_pretty(res.header)
+        echo_pretty(res.text)
+    click.echo(json.dumps(res.json()))
+
+
+@coverage.command(help="Retrieve the list of indicators for which no data is available")
+@click.option("--remote", "-r", is_flag=True, help="Send the request to the remote server")
+@click.option("--group", "-g", type=str, help="CountryGroup (default: SSPI67)")
+def unimplemented(remote=False, group="SSPI67"):
+    connector = SSPIDatabaseConnector()
+    request_string = "/api/v1/utilities/coverage/unimplemented"
+    if group:
+        request_string += f"?CountryGroup={group}"
+    res = connector.call(request_string, remote=remote)
+    if res.status_code != 200:
+        raise click.ClickException(
+            f"Error! Compute Request Failed with Status Code {res.status_code}"
+        )
+        echo_pretty(res.header)
+        echo_pretty(res.text)
+    click.echo(json.dumps(res.json()))
+
+
+@coverage.command(help="Generate a coverage report for a specific indicator")
+@click.argument("code", type=str, required=True)
+@click.option("--remote", "-r", is_flag=True, help="Send the request to the remote server")
+@click.option("--group", "-g", type=str, help="CountryGroup (default: SSPI67)")
+def report(code, remote=False, group="SSPI67"):
+    """
+    Generate a coverage report for a specific indicator.
+    :param code: The code of the indicator or country to generate the report for.
+    """
+    connector = SSPIDatabaseConnector()
+    code = code.upper()
+    if len(code) == 3:
+        request_string = f"/api/v1/utilities/coverage/report/country/{code}"
+    elif len(code) == 6:
+        request_string = f"/api/v1/utilities/coverage/report/indicator/{code}"
+    else:
+        raise click.ClickException((
+            "Invalid Code Error! The code must be either 3 characters (for a "
+            "country) or 6 characters (for an indicator)."
+        ))
+    if group:
+        request_string += f"?CountryGroup={group}"
+    res = connector.call(request_string, remote=remote)
+    if res.status_code != 200:
+        raise click.ClickException(
+            f"Error! Compute Request Failed with Status Code {res.status_code}"
+        )
+        echo_pretty(res.header)
+        echo_pretty(res.text)
+    msg = res.text
+    lines = msg.splitlines()
+    for line in lines:
+        if "has complete coverage" in line:
+            click.secho(line, fg="green")
+        else:
+            echo_pretty(line)

--- a/cli/commands/coverage.py
+++ b/cli/commands/coverage.py
@@ -1,0 +1,19 @@
+import click
+from connector import SSPIDatabaseConnector
+from cli.utilities import echo_pretty
+import json
+
+
+@click.command(help="Compute data coverage")
+@click.option("--remote", "-r", is_flag=True, help="Send the request to the remote server")
+def coverage(remote=False):
+    connector = SSPIDatabaseConnector()
+    request_string = "/api/v1/utilities/coverage"
+    res = connector.call(request_string, remote=remote)
+    if res.status_code != 200:
+        raise click.ClickException(
+            f"Error! Compute Request Failed with Status Code {res.status_code}"
+        )
+        echo_pretty(res.header)
+        echo_pretty(res.text)
+    click.echo(json.dumps(res.json()))

--- a/cli/utilities.py
+++ b/cli/utilities.py
@@ -26,14 +26,19 @@ def is_numeric_string(string):
 def echo_pretty(msg):
     if type(msg) is bytes:
         msg = msg.decode("utf-8")
-    tokens = msg.split(" ")
-    output = []
-    for i, t in enumerate(tokens):
-        if is_numeric_string(t):
-            output.append(click.style(t, fg='cyan'))
-        else:
-            output.append(t)
-    click.echo(" ".join(output))
+    lines = msg.splitlines()
+    for line in lines:
+        if "error:" in line[0:8] or "problem:" in line[0:9]:
+            click.secho(line.split(": ", 1)[1], fg='red')
+            continue
+        tokens = re.split(r"([\[\],()\s]+)", line)
+        output = []
+        for i, t in enumerate(tokens):
+            if is_numeric_string(t):
+                output.append(click.style(t, fg='cyan'))
+            else:
+                output.append(t)
+        click.echo("".join(output))
 
 
 def require_confirmation(phrase="CONFIRM", prompt="Type {0} to confirm") -> bool:

--- a/sspi_flask_app/api/core/dashboard.py
+++ b/sspi_flask_app/api/core/dashboard.py
@@ -19,7 +19,8 @@ from flask import (
     render_template,
     current_app as app
 )
-from ...models.sspi import SSPI
+from sspi_flask_app.models.sspi import SSPI
+from sspi_flask_app.models.coverage import DataCoverage
 from flask_login import login_required
 from sspi_flask_app.models.database import (
     sspi_main_data_v3,
@@ -640,3 +641,9 @@ def get_panel_plot(panel_id):
         "yMin": yMin,
         "yMax": yMax
     })
+
+
+@dashboard_bp.route("/utilities/coverage", methods=["GET"])
+def coverage():
+    coverage = DataCoverage(2000, 2023, "SSPI49").clean_data_coverage
+    return parse_json(coverage)

--- a/sspi_flask_app/api/core/dashboard.py
+++ b/sspi_flask_app/api/core/dashboard.py
@@ -645,5 +645,41 @@ def get_panel_plot(panel_id):
 
 @dashboard_bp.route("/utilities/coverage", methods=["GET"])
 def coverage():
-    coverage = DataCoverage(2000, 2023, "SSPI49").clean_data_coverage
+    group = request.args.get("CountryGroup", "SSPI67")
+    coverage = DataCoverage(2000, 2023, group).combined_coverage
     return parse_json(coverage)
+
+
+@dashboard_bp.route("/utilities/coverage/complete", methods=["GET"])
+def coverage_complete():
+    group = request.args.get("CountryGroup", "SSPI67")
+    coverage = DataCoverage(2000, 2023, group).complete()
+    return parse_json(coverage)
+
+
+@dashboard_bp.route("/utilities/coverage/incomplete", methods=["GET"])
+def coverage_incomplete():
+    group = request.args.get("CountryGroup", "SSPI67")
+    coverage = DataCoverage(2000, 2023, group).incomplete()
+    return parse_json(coverage)
+
+
+@dashboard_bp.route("/utilities/coverage/unimplemented", methods=["GET"])
+def coverage_unimplemented():
+    group = request.args.get("CountryGroup", "SSPI67")
+    coverage = DataCoverage(2000, 2023, group).unimplemented()
+    return parse_json(coverage)
+
+
+@dashboard_bp.route("/utilities/coverage/report/indicator/<IndicatorCode>", methods=["GET"])
+def coverage_indicator(IndicatorCode):
+    group = request.args.get("CountryGroup", "SSPI67")
+    coverage = DataCoverage(2000, 2023, group).indicator_report(IndicatorCode)
+    return coverage
+
+
+@dashboard_bp.route("/utilities/coverage/report/country/<CountryCode>", methods=["GET"])
+def coverage_country(CountryCode):
+    group = request.args.get("CountryGroup", "SSPI67")
+    coverage = DataCoverage(2000, 2023, group).country_report(CountryCode)
+    return coverage

--- a/sspi_flask_app/models/coverage.py
+++ b/sspi_flask_app/models/coverage.py
@@ -23,6 +23,9 @@ class DataCoverage:
         ]
         self.clean_data_coverage = self.get_coverage(sspi_clean_api_data)
         self.imputed_data_coverage = self.get_coverage(sspi_imputed_data)
+        self.combined_coverage = self.union(
+            self.clean_data_coverage, self.imputed_data_coverage
+        )
 
     def get_coverage(self, database):
         """
@@ -52,3 +55,64 @@ class DataCoverage:
             years = sorted(entry["yearList"])
             nested_dict.setdefault(ind, {})[ctry] = years
         return nested_dict
+
+    def union(self, cov_dict1: dict, cov_dict2: dict):
+        """
+        Compute the union of two coverage dictionaries to find their combined
+        coverage
+        :param cov_dict1: The first coverage dictionary (output format of get_coverage)
+        :param cov_dict2: The second coverage dictionary (output format of get_coverage)
+        """
+        merged = {}
+        for ind_code in set(cov_dict1.keys()).union(cov_dict2.keys()):
+            merged.setdefault(ind_code, {})
+            countries1 = cov_dict1.get(ind_code, {})
+            countries2 = cov_dict2.get(ind_code, {})
+            for ctry_code in set(countries1.keys()).union(countries2.keys()):
+                years1 = set(countries1.get(ctry_code, []))
+                years2 = set(countries2.get(ctry_code, []))
+                merged[ind_code][ctry_code] = sorted(years1.union(years2))
+        return merged
+
+    def check_complete_country(self, year_list):
+        """
+        Check whether the coverage is complete for a given country
+        :param year_list: The list of years for a given country, given as the
+        value of the CountryCode key in the coverage dictionary
+        """
+        return all([
+            year in range(self.min_year, self.max_year + 1)
+            for year in year_list
+        ])
+
+    def check_complete_indicator(self, country_year_dict):
+        """
+        Check whether the coverage is complete for a given indicator
+        :param country_year_dict: The dictionary of countries and years for a
+        given indicator, given as the value of the IndicatorCode key in the
+        coverage dictionary
+        """
+        return all([
+            self.check_complete_country(year_list)
+            for year_list in country_year_dict.values()
+        ])
+
+    def complete(self):
+        complete_list = []
+        for indicator in self.indicator_codes:
+            if indicator not in self.combined_coverage.keys():
+                continue
+            country_year_dict = self.combined_coverage[indicator]
+            if self.check_complete_indicator(country_year_dict):
+                complete_list.append(indicator)
+        return complete_list
+
+    def incomplete(self):
+        incomplete_list = []
+        for indicator in self.indicator_codes:
+            if indicator not in self.combined_coverage.keys():
+                continue
+            country_year_dict = self.combined_coverage[indicator]
+            if not self.check_complete_indicator(country_year_dict):
+                incomplete_list.append(indicator)
+        return incomplete_list

--- a/sspi_flask_app/models/coverage.py
+++ b/sspi_flask_app/models/coverage.py
@@ -1,0 +1,58 @@
+from sspi_flask_app.models.database import (
+    sspi_metadata,
+    sspi_clean_api_data,
+    sspi_imputed_data
+)
+
+
+class DataCoverage:
+    def __init__(self, min_year: int, max_year: int, country_group: str, countries: list[str] = [], indicator_details: list[str] = []):
+        self.min_year = min_year
+        self.max_year = max_year
+        self.country_group = country_group
+        if not country_group and countries:
+            self.countries = countries
+        else:
+            self.countries = sspi_metadata.country_group(country_group)
+        if not indicator_details:
+            self.indicator_details = sspi_metadata.indicator_details()
+        else:
+            self.indicator_details = indicator_details
+        self.indicator_codes = [
+            indicator["IndicatorCode"] for indicator in self.indicator_details
+        ]
+        self.clean_data_coverage = self.get_clean_coverage()
+
+    def get_clean_coverage(self):
+        """
+        Get the coverage of the clean data
+        """
+        pipeline = [
+            {
+                "$group": {
+                    "_id": {
+                        "IndicatorCode": "$IndicatorCode",
+                        "CountryCode": "$CountryCode"
+                    },
+                    "yearList": {
+                        "$push": {
+                            "$cond": [{"$gt": ["$Year", self.min_year]}, "$Year", "$$REMOVE"]
+                        }
+                    },
+                }
+            },
+            {
+                "$project": {
+                    "_id": 0,
+                    "IndicatorCode": "$_id.IndicatorCode",
+                    "CountryCode": "$_id.CountryCode",
+                    "yearList": {
+                        "$sortArray": {
+                            "input": "$yearList",
+                            "sortBy": 1
+                        }
+                    }
+                }
+            }
+        ]
+        return sspi_clean_api_data.aggregate(pipeline)

--- a/sspi_flask_app/models/database/mongo_wrapper.py
+++ b/sspi_flask_app/models/database/mongo_wrapper.py
@@ -49,6 +49,13 @@ class MongoWrapper:
         """
         return self._mongo_database.distinct(field)
 
+    def aggregate(self, pipeline, options={"_id": 0}):
+        """
+        Aggregates the data in the collection using the provided pipeline.
+        """
+        cursor = self._mongo_database.aggregate(pipeline)
+        return json.loads(json_util.dumps(cursor))
+
     def tabulate_ids(self) -> list:
         """
         Returns a list of documents with counts of the number of

--- a/sspi_flask_app/models/database/sspi_clean_api_data.py
+++ b/sspi_flask_app/models/database/sspi_clean_api_data.py
@@ -56,13 +56,6 @@ class SSPICleanAPIData(MongoWrapper):
             raise InvalidDocumentFormatError(
                 f"'Score' must be a float or integer (document {document_number})")
 
-    def aggregate(self, pipeline, options={"_id": 0}):
-        """
-        Aggregates the data in the collection using the provided pipeline.
-        """
-        cursor = self._mongo_database.aggregate(pipeline)
-        return json.loads(json_util.dumps(cursor))
-
 
 class SSPIIncompleteAPIData(SSPICleanAPIData):
     """


### PR DESCRIPTION
## DevLog Summary
- Implemented DataCoverage class with methods and properties designed to answer common questions about dynamic data coverage
- Implemented Dashboard routes to expose the methods of interest
- Implemented CLI for interacting with the DataCoverage dashboard routes
- Minor improvements to the `echo_pretty` CLI Utility: 
    - Prepending "problem:" or "error:" -> click.secho(msg, fg="red")
    - Now looks line by line instead of rendering whole blocks, allowing finer grained control of message styling.

## Commits
- **feat: Implemented DataCoverage Skeleton**
- **feat: Registered Coverage Command**
- **feat: Implemented Basic Coverage Route**
- **fix: Moved aggregate method to MongoWrapper**
- **feat: DataCoverage is now a nested dictionary**
- **feat: Implemented union(), complete(), and incomplete() methods**
- **feat: Implemented Coverage Report Functionality for COU and IDCODE**
