### PR TITLE
588 implement apiv1imputewatman

### DIFF
--- a/cli/commands/extrapolate.py
+++ b/cli/commands/extrapolate.py
@@ -10,8 +10,9 @@ def extrapolate():
 
 
 @extrapolate.command(help="Extrapolate backward from first observation for a given indicator")
-@click.argument("year", type=int)
-def backward(year):
+@click.argument("year", type=int, required=True)
+@click.option('--series-id', "-s", multiple=True, required=False, default=["CountryCode", "IndicatorCode"], help="List of strings specifying the series identifiers")
+def backward(year, series_id):
     """Read data from standard input and extrapolate backward missing data for a given indicator"""
     if stdin_is_empty():
         raise click.ClickException("No input provided")
@@ -22,6 +23,9 @@ def backward(year):
         raise click.ClickException("Invalid JSON input")
     connector = SSPIDatabaseConnector()
     request_string = f"/api/v1/utilities/extrapolate/backward/{year}"
+    if series_id:
+        param_list = ["SeriesID={}&".format(sid) for sid in series_id]
+        request_string += "?" + "".join(param_list)[:-1]
     res = connector.call(request_string, method="POST", data=data)
     if res.status_code != 200:
         raise click.ClickException(

--- a/cli/commands/impute.py
+++ b/cli/commands/impute.py
@@ -11,7 +11,7 @@ def impute(indicator_code, remote=False):
     connector = SSPIDatabaseConnector()
     indicator_code = indicator_code.upper()
     request_string = f"/api/v1/impute/{indicator_code}"
-    res = connector.call(request_string, remote=remote)
+    res = connector.call(request_string, method="POST", remote=remote)
     if res.status_code != 200:
         raise click.ClickException(
             f"Error! Compute Request Failed with Status Code {res.status_code}"

--- a/sspi_flask_app/api/core/compute/SUS/compute_lnd.py
+++ b/sspi_flask_app/api/core/compute/SUS/compute_lnd.py
@@ -67,6 +67,7 @@ def compute_watman():
     """
     app.logger.info("Running /api/v1/compute/WATMAN")
     sspi_clean_api_data.delete_many({"IndicatorCode": "WATMAN"})
+    sspi_incomplete_api_data.delete_many({"IndicatorCode": "WATMAN"})
     raw_data = sspi_raw_api_data.fetch_raw_data("WATMAN")
     watman_data = extract_sdg(raw_data)
     intermediate_map = {

--- a/sspi_flask_app/api/core/compute/SUS/compute_lnd.py
+++ b/sspi_flask_app/api/core/compute/SUS/compute_lnd.py
@@ -86,17 +86,17 @@ def compute_watman():
     return parse_json(clean_list)
 
 
-@compute_bp.route("/STKHLM", methods=['GET'])
+@compute_bp.route("/CHMPOL", methods=['GET'])
 @login_required
-def compute_stkhlm():
-    app.logger.info("Running /api/v1/compute/STKHLM")
-    sspi_clean_api_data.delete_many({"IndicatorCode": "STKHLM"})
-    raw_data = sspi_raw_api_data.fetch_raw_data("STKHLM")
-    extracted_stkhlm = extract_sdg(raw_data)
-    filtered_stkhlm = filter_sdg(
-        extracted_stkhlm, {"SG_HAZ_CMRSTHOLM": "STKHLM"},
+def compute_chmpol():
+    app.logger.info("Running /api/v1/compute/CHMPOL")
+    sspi_clean_api_data.delete_many({"IndicatorCode": "CHMPOL"})
+    raw_data = sspi_raw_api_data.fetch_raw_data("CHMPOL")
+    extracted_chmpol = extract_sdg(raw_data)
+    filtered_chmpol = filter_sdg(
+        extracted_chmpol, {"SG_HAZ_CMRSTHOLM": "CHMPOL"},
     )
-    scored_list = score_single_indicator(filtered_stkhlm, "STKHLM")
+    scored_list = score_single_indicator(filtered_chmpol, "CHMPOL")
     sspi_clean_api_data.insert_many(scored_list)
     return parse_json(scored_list)
 

--- a/sspi_flask_app/api/core/dashboard.py
+++ b/sspi_flask_app/api/core/dashboard.py
@@ -421,6 +421,7 @@ def do_backward_extrapolate(year: int):
     """
     Extrapolate backward missing data for a given indicator
     """
+    series_id = request.args.getlist("SeriesID")
     if not request.is_json:
         return jsonify({"error": "Content-Type must be application/json"}), 400
     data = request.get_json(silent=True)
@@ -430,6 +431,8 @@ def do_backward_extrapolate(year: int):
         return jsonify({"error": "Data must be a list"}), 400
     if not all(isinstance(item, dict) for item in data):
         return jsonify({"error": "All items in data must be dictionaries"}), 400
+    if series_id:
+        return parse_json(extrapolate_backward(data, year, series_id=series_id))
     return parse_json(extrapolate_backward(data, year))
 
 
@@ -438,6 +441,7 @@ def do_forward_extrapolate(year: int):
     """
     Extrapolate backward missing data for a given indicator
     """
+    series_id = request.args.getlist("SeriesID")
     if not request.is_json:
         return jsonify({"error": "Content-Type must be application/json"}), 400
     data = request.get_json(silent=True)
@@ -447,6 +451,8 @@ def do_forward_extrapolate(year: int):
         return jsonify({"error": "Data must be a list"}), 400
     if not all(isinstance(item, dict) for item in data):
         return jsonify({"error": "All items in data must be dictionaries"}), 400
+    if series_id:
+        return parse_json(extrapolate_forward(data, year, series_id=series_id))
     return parse_json(extrapolate_forward(data, year))
 
 

--- a/sspi_flask_app/api/core/impute.py
+++ b/sspi_flask_app/api/core/impute.py
@@ -9,9 +9,13 @@ from sspi_flask_app.models.database import (
 )
 from sspi_flask_app.api.resources.utilities import (
     parse_json,
+    zip_intermediates,
     extrapolate_backward,
     extrapolate_forward,
-    interpolate_linear
+    interpolate_linear,
+    slice_intermediate,
+    filter_imputations,
+    impute_global_average
 )
 
 
@@ -23,22 +27,59 @@ impute_bp = Blueprint(
 )
 
 
-@impute_bp.route("/BIODIV", methods=["GET"])
+@impute_bp.route("/BIODIV", methods=["POST"])
 def impute_biodiv():
     sspi_imputed_data.delete_many({"IndicatorCode": "SENIOR"})
     clean_list = sspi_clean_api_data.find({"IndicatorCode": "BIODIV"})
-    incomplete_list = sspi_imputed_data.find({"IndicatorCode": "BIODIV"})
+    incomplete_list = sspi_incomplete_api_data.find({"IndicatorCode": "BIODIV"})
     # Do imputation logic here
     documents = []
     count = sspi_imputed_data.insert_many(documents)
     return parse_json(documents)
 
 
-@impute_bp.route("/SENIOR", methods=["GET"])
-def impute_senior(IndicatorCode):
+@impute_bp.route("/WATMAN", methods=["POST"])
+def impute_watman():
+    mongo_query = {"IndicatorCode": "WATMAN"}
+    sspi_imputed_data.delete_many(mongo_query)
+    clean_list = sspi_clean_api_data.find(mongo_query)
+    incomplete_list = sspi_incomplete_api_data.find(mongo_query)
+    # Extract clean CWUEFF Data and Extrapolate Backwards
+    clean_cwueff = slice_intermediate(clean_list, "CWUEFF") + \
+        slice_intermediate(incomplete_list, "CWUEFF")
+    imputed_cwueff = extrapolate_backward(
+        clean_cwueff, 2000, series_id=["CountryCode", "IntermediateCode"]
+    )
+    imputed_cwueff = extrapolate_forward(
+        imputed_cwueff, 2023, series_id=["CountryCode", "IntermediateCode"]
+    )
+    # Impute CWUEFF Data for SGP
+    sgp_cwueff = impute_global_average("SGP", 2000, 2023, clean_cwueff)
+    # Extract matched WTSTRS Data
+    clean_wtstrs = slice_intermediate(clean_list, "WTSTRS") + \
+        slice_intermediate(incomplete_list, "WTSTRS")
+    imputed_wtstrs = extrapolate_backward(
+        clean_wtstrs, 2000, series_id=["CountryCode", "IntermediateCode"]
+    )
+    imputed_wtstrs = extrapolate_forward(
+        imputed_wtstrs, 2023, series_id=["CountryCode", "IntermediateCode"]
+    )
+    overall_watman, missing_imputations = zip_intermediates(
+        imputed_wtstrs + imputed_cwueff + sgp_cwueff, "WATMAN",
+        ScoreFunction=lambda CWUEFF, WTSTRS: (CWUEFF + WTSTRS) / 2,
+        ScoreBy="Score"
+    )
+    imputed_watman = filter_imputations(overall_watman)
+    sspi_imputed_data.insert_many(imputed_watman)
+    return parse_json(imputed_watman)
+
+
+@impute_bp.route("/SENIOR", methods=["POST"])
+def impute_senior():
     sspi_imputed_data.delete_many({"IndicatorCode": "SENIOR"})
     clean_data = sspi_clean_api_data.find({"IndicatorCode": "SENIOR"})
-    incomplete_list = sspi_imputed_data.find({"IndicatorCode": "SENIOR"})
+    incomplete_list = sspi_incomplete_api_data.find(
+        {"IndicatorCode": "SENIOR"})
     # Do imputation logic here
     count = sspi_imputed_data.insert_many([])
     return f"{count} documents inserted into sspi_imputed_data."

--- a/sspi_flask_app/api/resources/utilities.py
+++ b/sspi_flask_app/api/resources/utilities.py
@@ -540,3 +540,35 @@ def generate_item_groups(data: list[dict], entity_id="", value_id="", time_id=""
             "score_id": obs.get(score_id, None),
         })
     return list(item_levels.values())
+
+
+def slice_intermediate(doc_list, intermediate_code):
+    """
+    Utility taking for extracting intermediates from the output of
+    zip_intermediates
+
+    :param doc_list: List of documents to extract intermediates from, in the
+    format of the output of zip_intermediates.
+    :param intermediate_code: The code of the intermediate to extract.
+    """
+    intermediates = []
+    for doc in doc_list:
+        for intermediate in doc.get('Intermediates', []):
+            if intermediate.get('IntermediateCode') == intermediate_code:
+                intermediates.append(intermediate)
+    return intermediates
+
+
+def filter_imputations(doc_list):
+    """
+    Utility taking for extracting imputations from the output of
+    zip_intermediates
+
+    :param doc_list: List of documents to extract intermediates from, in the
+    format of the output of zip_intermediates.
+    """
+    imputations = []
+    for doc in doc_list:
+        if any([i.get('Imputed', False) for i in doc.get('Intermediates', [])]):
+            imputations.append(doc)
+    return imputations

--- a/sspi_flask_app/api/resources/utilities.py
+++ b/sspi_flask_app/api/resources/utilities.py
@@ -572,3 +572,31 @@ def filter_imputations(doc_list):
         if any([i.get('Imputed', False) for i in doc.get('Intermediates', [])]):
             imputations.append(doc)
     return imputations
+
+
+def impute_global_average(country_code: str, start_year: int, end_year: int, ref_data: list[dict]):
+    """
+    Impute the global average for a given country and year range.
+
+    :param country_code: The country code to impute.
+    :param start_year: The starting year for the imputation.
+    :param end_year: The ending year for the imputation.
+    :param ref_data: The reference data to calculate the global average.
+    """
+    mean_value = sum([x["Value"] for x in ref_data]) / len(ref_data)
+    mean_score = sum([x["Score"] for x in ref_data]) / len(ref_data)
+    if not all([x["Unit"] == ref_data[0]["Unit"] for x in ref_data]):
+        raise ValueError("Units are not consistent across reference data.")
+    return [
+        {
+            "CountryCode": "SGP",
+            "IntermediateCode": "CWUEFF",
+            "Value": mean_value,
+            "Score": mean_score,
+            "Year": year,
+            "Unit": ref_data[0]["Unit"],
+            "Imputed": True,
+            "ImputationMethod": "ImputeGlobalAverage",
+        }
+        for year in range(start_year, end_year + 1)
+    ]

--- a/sspi_flask_app/models/coverage.py
+++ b/sspi_flask_app/models/coverage.py
@@ -148,6 +148,8 @@ class DataCoverage:
                     continue
                 missing = [y for y in range(self.min_year, self.max_year)
                            if y not in country_year_dict[country]]
+                if len(missing) == 0:
+                    continue
                 msg += f"\n{country} missing years {missing}."
         return msg
 
@@ -172,5 +174,7 @@ class DataCoverage:
             else:
                 missing = [y for y in range(self.min_year, self.max_year + 1)
                            if y not in country_year_dict[country_code]]
+                if len(missing) == 0:
+                    continue
                 msg += f"\nIndicator code {indicator} missing years {missing}."
         return msg

--- a/sspi_flask_app/models/coverage.py
+++ b/sspi_flask_app/models/coverage.py
@@ -146,7 +146,7 @@ class DataCoverage:
                 if len(country_year_dict[country]) == 0:
                     msg += f"\nproblem: {country} has no observations."
                     continue
-                missing = [y for y in range(self.min_year, self.max_year)
+                missing = [y for y in range(self.min_year, self.max_year + 1)
                            if y not in country_year_dict[country]]
                 if len(missing) == 0:
                     continue


### PR DESCRIPTION
Pull request implements impute_watman. In the course of imputing this indicator,
several general utility functions for working with future imputations were implemented.
- `impute_global_average` takes a CountryCode, Year Range, and Reference Data. It is designed
to handle cases in which all data for a given country is missing for an intermediate or indicator.
- `filter_imputations` takes in the output of zip_intermediates, and is used to keep imputed data
separate from real data.
- A number of small issues were also found and fixed. *See below*.

- **fix: Coverage Messages Only Show Missing Countries**
- **fix: CLI Command Impute Method Now Calls POST**
- **feat: Extrapolate Now Handles Custom SeriesIDs**
- **feat: Implemented Imputation Utilties**
- **fix: Updated STKHLM -> CHMPOL in Compute**
- **fix: All Missing Years are Now Displayed (No Longer Off by One)**
- **fix: Compute WATMAN Deletes Incomplete Data on Run**
- **feat: Implemented impute_global_average Utility**
