### PR TITLE
592 implement apiv1imputealtnrg

### DIFF
--- a/sspi_flask_app/api/core/sspi/sus/nrg/altnrg.py
+++ b/sspi_flask_app/api/core/sspi/sus/nrg/altnrg.py
@@ -1,16 +1,24 @@
-from sspi_flask_app.api.core.sspi import collect_bp
-from sspi_flask_app.api.core.sspi import compute_bp
-from flask_login import login_required, current_user
-from flask import current_app as app, Response
-from sspi_flask_app.api.datasource.iea import collectIEAData, cleanIEAData_altnrg
-from sspi_flask_app.models.database import (
-    sspi_raw_api_data,
-    sspi_clean_api_data,
-    sspi_incomplete_api_data,
-)
-from sspi_flask_app.api.resources.utilities import parse_json, zip_intermediates
-import pandas as pd
 import json
+
+import pandas as pd
+from flask import Response
+from flask import current_app as app
+from flask_login import current_user, login_required
+
+from sspi_flask_app.api.core.sspi import collect_bp, compute_bp, impute_bp
+from sspi_flask_app.api.datasource.iea import cleanIEAData_altnrg, collectIEAData
+from sspi_flask_app.api.resources.utilities import (
+    extrapolate_forward,
+    parse_json,
+    zip_intermediates,
+    slice_intermediate
+)
+from sspi_flask_app.models.database import (
+    sspi_clean_api_data,
+    sspi_imputed_data,
+    sspi_incomplete_api_data,
+    sspi_raw_api_data,
+)
 
 
 @collect_bp.route("/ALTNRG", methods=["GET"])
@@ -40,6 +48,7 @@ def compute_altnrg():
     """
     app.logger.info("Running /api/v1/compute/ALTNRG")
     sspi_clean_api_data.delete_many({"IndicatorCode": "ALTNRG"})
+    sspi_incomplete_api_data.delete_many({"IndicatorCode": "ALTNRG"})
     raw_data = sspi_raw_api_data.fetch_raw_data("ALTNRG")
     metadata_code_map = {
         "COAL": "TLCOAL",
@@ -104,3 +113,90 @@ def compute_altnrg():
     sspi_clean_api_data.insert_many(clean_list)
     sspi_incomplete_api_data.insert_many(incomplete_list)
     return parse_json(clean_list)
+
+
+@impute_bp.route("/ALTNRG", methods=["POST"])
+@login_required
+def impute_altnrg():
+    """
+    Imputation for alternative energy sources is not implemented yet.
+    """
+    app.logger.info("Running /api/v1/impute/ALTNRG")
+    sspi_imputed_data.delete_many({"IndicatorCode": "ALTNRG"})
+    # Forward Extrapolate from 2022 to 2023
+    clean_data = sspi_clean_api_data.find({"IndicatorCode": "ALTNRG"})
+    forward_extrap = extrapolate_forward(clean_data, 2023, impute_only=True)
+    # Handle KWT: All sources confirm that almost all energy is from fossil fuels
+    kwt_incomplete = sspi_incomplete_api_data.find(
+        {"IndicatorCode": "ALTNRG", "CountryCode": "KWT"}
+    )
+    impute_info = {
+        "Imputed": True,
+        "ImputationMethod": "ManualSourcing",
+        "ImputationDescription": (
+            "Kuwait's energy supply is almost entirely from fossil "
+                "fuels, with negligible contributions from renewable "
+                "sources, which includes Biowaste sources. Most of the "
+                "available sources are from recent years, but given KWT's "
+                "long-standing status as a major oil producer, it is "
+                "reasonable to assume that this pattern has been consistent"
+                " for many years."
+        ),
+        "ImputationSources": [
+            {
+                "URL": "https://www.iea.org/countries/kuwait/energy-mix",
+                "Evidence": "Oil and natural gas account for >99% of Kuwait's Total Energy Supply in 2022. See figure ' Largest source of energy in Kuwait, 2022.'",
+            },
+            {
+                "URL": "https://www.eia.gov/international/content/analysis/countries_long/Kuwait/kuwait.pdf",
+                "Evidence": "Primary energy consumption by fuel is >99% petroleum/other liquids and natural gas in 2021.",
+            },
+            {
+                "URL": "https://www.irena.org/-/media/Files/IRENA/Agency/Statistics/Statistical_Profiles/Middle%20East/Kuwait_Middle%20East_RE_SP.pdf",
+                "Evidence": "Renewable energy supply is only 8715 TJ out of 517,966 TJ of TES in 2021, and only 619 TJ in 2016.",
+            },
+        ]
+    }
+    kwt_incomplete_filtered = []
+    for i, obs in enumerate(kwt_incomplete):
+        obs["Imputed"] = True
+        obs["ImputationMethod"] = True
+        obs["ImputationDistance"] = 0
+        year = obs["Year"]
+        country_code = obs["CountryCode"]
+        if not obs.get("Intermediates"):
+            continue
+        int_codes = [inter["IntermediateCode"] for inter in obs["Intermediates"]]
+        if "TTLSUM" not in int_codes:
+            continue
+        if "BIOWAS" not in int_codes:
+            imputed_intermediate = {
+                "IntermediateCode": "BIOWAS",
+                "Value": 0.0,
+                "Unit": "TJ",
+                "Year": year,
+                "CountryCode": country_code
+            }
+            imputed_intermediate.update(impute_info)
+            obs["Intermediates"].append(imputed_intermediate)
+        if "ALTSUM" not in int_codes:
+            imputed_intermediate = {
+                "IntermediateCode": "ALTSUM",
+                "Value": 0.0,
+                "Unit": "TJ",
+                "Year": year,
+                "CountryCode": country_code
+            }
+            imputed_intermediate.update(impute_info)
+            obs["Intermediates"].append(imputed_intermediate)
+        kwt_incomplete_filtered.append(obs)
+    kwt_clean, kwt_still_missing = zip_intermediates(
+        slice_intermediate(kwt_incomplete_filtered, ["TTLSUM", "ALTSUM", "BIOWAS"]),
+        "ALTNRG", 
+        ScoreFunction=lambda TTLSUM, ALTSUM, BIOWAS: (ALTSUM - 0.5 * BIOWAS) / TTLSUM,
+        ValueFunction=lambda TTLSUM, ALTSUM, BIOWAS: (ALTSUM - 0.5 * BIOWAS) / TTLSUM * 100,
+        ScoreBy="Value",
+    )
+    imputations = kwt_clean + forward_extrap
+    sspi_imputed_data.insert_many(imputations)
+    return parse_json(imputations)

--- a/sspi_flask_app/api/resources/utilities.py
+++ b/sspi_flask_app/api/resources/utilities.py
@@ -535,19 +535,23 @@ def generate_item_groups(data: list[dict], entity_id="", value_id="", time_id=""
     return list(item_levels.values())
 
 
-def slice_intermediate(doc_list, intermediate_code):
+def slice_intermediate(doc_list, intermediate_codes: list[str] | str):
     """
     Utility taking for extracting intermediates from the output of
     zip_intermediates
 
     :param doc_list: List of documents to extract intermediates from, in the
     format of the output of zip_intermediates.
-    :param intermediate_code: The code of the intermediate to extract.
+    :param intermediate_codes: List of intermediate codes to filter by, or a single
+    intermediate code as a string.
     """
     intermediates = []
+    if not isinstance(intermediate_codes, list):
+        intermediate_codes = [intermediate_codes]
     for doc in doc_list:
+        print(doc)
         for intermediate in doc.get('Intermediates', []):
-            if intermediate.get('IntermediateCode') == intermediate_code:
+            if intermediate.get('IntermediateCode') in intermediate_codes:
                 intermediates.append(intermediate)
     return intermediates
 

--- a/sspi_flask_app/models/database/mongo_wrapper.py
+++ b/sspi_flask_app/models/database/mongo_wrapper.py
@@ -306,12 +306,9 @@ class MongoWrapper:
             id_set.add(document_id)
 
     def validate_intermediates_list(self, intermediates: list, document_number: int = 0):
-        if not type(intermediates) is list:
-            print(f"Document Produced an Error: {intermediates}")
-            raise InvalidDocumentFormatError(f"'Intermediates' must be a list (document {document_number}); got type {type(intermediates)}")
         id_set = set()
         for intermediate in intermediates:
-            if not type(intermediate) is dict:
+            if not isinstance(intermediate, dict):
                 print(f"Document Produced an Error: {intermediates}")
                 raise InvalidDocumentFormatError(
                     f"'Intermediates' must be a dictionary (document {document_number})")


### PR DESCRIPTION
Standardized a format for `"ManualSource"` Imputations, i.e. imputations handled by looking up sources piecemeal.

- **chore: Bumped Documentation Submodule Version**
- **fix: Removed Unnecessary Type Check**
- **feat: slice_intermediate can now take a list as well as a string**
- **feat: Implemented /api/v1/impute/ALTNRG**
