### PR TITLE
210 implement skeleton for datacountryccode

### DIFF
--- a/cli/cli.py
+++ b/cli/cli.py
@@ -14,6 +14,7 @@ from cli.commands.pull import pull
 from cli.commands.push import push
 from cli.commands.query import query
 from cli.commands.save import save
+from cli.commands.url import url
 from cli.commands.view import view
 
 
@@ -37,4 +38,5 @@ cli.add_command(pull)
 cli.add_command(push)
 cli.add_command(query)
 cli.add_command(save)
+cli.add_command(url)
 cli.add_command(view)

--- a/cli/commands/url.py
+++ b/cli/commands/url.py
@@ -1,0 +1,13 @@
+import click
+from connector import SSPIDatabaseConnector
+import json
+
+
+@click.command(help="Hit a URL stub")
+@click.argument("url_stub", type=str, required=True)
+@click.option("--remote", "-r", is_flag=True, help="Send the request to the remote server")
+def url(url_stub, remote=False):
+    connector = SSPIDatabaseConnector()
+    request_string = url_stub
+    res = connector.call(request_string, remote=remote)
+    click.echo(json.dumps(res.json()))

--- a/cli/commands/view.py
+++ b/cli/commands/view.py
@@ -21,7 +21,7 @@ class DefaultGroup(click.Group):
             raise click.UsageError("Invalid command or IDCODE")
 
 
-@click.group(cls=DefaultGroup, invoke_without_command=True, help="View data visualizations")
+@click.group(cls=DefaultGroup, invoke_without_command=True, help="View webpages")
 @click.option("--remote", "-r", is_flag=True, help="Send the request to the remote server")
 @click.pass_context
 def view(ctx, remote=False):
@@ -88,6 +88,16 @@ def repo():
     """
     url = "https://github.com/tjmisko/sspi-data-webapp"
     open_browser_subprocess(url)
+
+
+@view.command(help="View GitHub Repo")
+def wiki():
+    """Open GitHub Project in browser
+    """
+    url = "https://github.com/tjmisko/sspi-data-webapp/wiki"
+    open_browser_subprocess(url)
+
+
 
 
 view.add_command(line)

--- a/sspi_flask_app/assets.py
+++ b/sspi_flask_app/assets.py
@@ -19,6 +19,7 @@ def compile_static_assets(assets):
         'client_bp/js/*.js',
         'client_bp/charts/plugins/*.js',
         'client_bp/charts/components/*.js',
+        'client_bp/charts/country-score-chart.js',
         'client_bp/charts/panel/panel-chart.js',
         'client_bp/charts/panel/item-panel-chart.js',
         'client_bp/charts/panel/score-panel-chart.js',

--- a/sspi_flask_app/client/routes.py
+++ b/sspi_flask_app/client/routes.py
@@ -41,7 +41,7 @@ def data():
 
 @client_bp.route('/data/country/<CountryCode>')
 def country_data(CountryCode):
-    return render_template('country-template.html', CountryCode=CountryCode)
+    return render_template('country-data.html', CountryCode=CountryCode)
 
 
 @client_bp.route('/data/indicator/<IndicatorCode>')

--- a/sspi_flask_app/client/static/charts/country-score-chart.js
+++ b/sspi_flask_app/client/static/charts/country-score-chart.js
@@ -1,0 +1,376 @@
+class CountryScoreChart {
+    constructor(parentElement, countryCode, rootItemCode, { colorProvider = SSPIColors } ) {
+        this.parentElement = parentElement// ParentElement is the element to attach the canvas to
+        this.endpointURL = "/api/v1/country/dynamic/stack/" + countryCode + "/" + rootItemCode
+        this.pins = new Set() // pins contains a list of pinned countries
+        this.colorProvider = colorProvider // colorProvider is an instance of ColorProvider
+        this.yAxisScale = "value"
+        this.endLabelPlugin = endLabelPlugin
+        this.extrapolateBackwardPlugin = extrapolateBackwardPlugin
+        this.setTheme(window.observableStorage.getItem("theme"))
+        this.initRoot()
+        this.initChartJSCanvas()
+        this.buildChartOptions()
+        this.rigChartOptions()
+        this.rigItemDropdown()
+        this.updateChartOptions()
+        this.fetch(this.endpointURL).then(data => {
+            this.update(data)
+        })
+        this.rigUnloadListener()
+    }
+
+    initRoot() {
+        // Create the root element
+        this.root = document.createElement('div')
+        this.root.classList.add('panel-chart-root-container')
+        this.parentElement.appendChild(this.root)
+    }
+
+    buildChartOptions() {
+        this.chartOptions = document.createElement('div')
+        this.chartOptions.classList.add('chart-options')
+        this.chartOptions.innerHTML = `
+            <button class="icon-button hide-chart-options" aria-label="Hide Chart Options" title="Hide Chart Options">
+                <svg class="hide-chart-options-svg" width="24" height="24">
+                    <use href="#icon-close" />
+                </svg>
+            </button>
+            <details class="item-information chart-options-details">
+                <summary class="item-information-summary">Item Information</summary>
+                <select class="item-dropdown"></select>
+                <div class="dynamic-item-description"></div>
+            </details>
+            <details class="download-data-details chart-options-details">
+                <summary>Download Chart Data</summary>
+                <form id="downloadForm">
+                    <fieldset>
+                        <legend>Select data scope:</legend>
+                        <label><input type="radio" name="scope" value="pinned" required>Pinned countries</label>
+                        <label><input type="radio" name="scope" value="visible">Visible countries</label>
+                        <label><input type="radio" name="scope" value="group">Countries in group</label>
+                        <label><input type="radio" name="scope" value="all">All available countries</label>
+                    </fieldset>
+                    <fieldset>
+                        <legend>Choose file format:</legend>
+                        <label><input type="radio" name="format" value="json" required>JSON</label>
+                        <label><input type="radio" name="format" value="csv">CSV</label>
+                    </fieldset>
+                    <button type="submit">Download Data</button>
+                </form>
+            </details>
+            `;
+        this.showChartOptions = document.createElement('button')
+        this.showChartOptions.classList.add("icon-button", "show-chart-options")
+        this.showChartOptions.ariaLabel = "Show Chart Options"
+        this.showChartOptions.title = "Show Chart Options"
+        this.showChartOptions.innerHTML = `
+            <svg class="svg-button show-chart-options-svg" width="24" height="24">
+                <use href="#icon-menu" />
+            </svg>
+        `;
+        this.root.appendChild(this.showChartOptions)
+        this.overlay = document.createElement('div')
+        this.overlay.classList.add('chart-options-overlay')
+        this.overlay.addEventListener('click', () => {
+            this.closeChartOptionsSidebar()
+        })
+        this.root.appendChild(this.overlay)
+        const wrapper = document.createElement('div')
+        wrapper.classList.add('chart-options-wrapper')
+        wrapper.appendChild(this.chartOptions)
+        this.root.appendChild(wrapper)
+    }
+
+    rigChartOptions() {
+        this.showChartOptions.addEventListener('click', () => {
+            this.openChartOptionsSidebar()
+        })
+        this.hideChartOptions = this.chartOptions.querySelector('.hide-chart-options')
+        this.hideChartOptions.addEventListener('click', () => {
+            this.closeChartOptionsSidebar()
+        })
+        let openDetails = window.observableStorage.getItem("openCountryChartDetails")
+        const detailsElements = this.chartOptions.querySelectorAll('.chart-options-details')
+        detailsElements.forEach((details) => {
+            if (openDetails && openDetails.includes(details.classList[0])) {
+                details.open = true
+            } else {
+                details.open = false
+            }
+        })
+        const sidebarStatus = window.observableStorage.getItem("chartOptionsStatus")
+        if (sidebarStatus === "active") {
+            this.openChartOptionsSidebar()
+        } else {
+            this.closeChartOptionsSidebar()
+        }
+    }
+
+    rigItemDropdown() {
+        this.itemInformation = this.chartOptions.querySelector('.item-information')
+        this.itemDropdown = this.itemInformation.querySelector('.item-dropdown')
+    }
+
+    initChartJSCanvas() {
+        this.chartContainer = document.createElement('div')
+        this.chartContainer.classList.add('panel-chart-container')
+        this.chartContainer.innerHTML = `
+            <h2 class="panel-chart-title"></h2>
+            <div class="panel-canvas-wrapper">
+                <canvas class="panel-chart-canvas"></canvas>
+            </div>
+        `;
+        this.root.appendChild(this.chartContainer)
+        this.title = this.chartContainer.querySelector('.panel-chart-title')
+        this.canvas = this.chartContainer.querySelector('.panel-chart-canvas')
+        this.context = this.canvas.getContext('2d')
+        this.chart = new Chart(this.context, {
+            type: 'line',
+            plugins: [this.endLabelPlugin, this.extrapolateBackwardPlugin],
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                datasets: {
+                    fill: true,
+                    line: {
+                        spanGaps: true,
+                        pointRadius: 2,
+                        pointHoverRadius: 4,
+                        segment: {
+                            borderWidth: 2,
+                            borderDash: ctx => {
+                                return ctx.p0.skip || ctx.p1.skip ? [10, 4] : [];
+                                // Dashed when spanning gaps, solid otherwise
+                            }
+                        }
+                    }
+                },
+                plugins: {
+                    legend: {
+                        display: false,
+                    },
+                    endLabelPlugin: {
+                        labelField: 'ICode'
+                    },
+                    tooltip: {
+                        mode: 'index',
+                    }
+                },
+                layout: {
+                    padding: {
+                        right: 40
+                    }
+                }
+            }
+        })
+    }
+
+    updateChartOptions() {
+        this.chart.options.scales = {
+            x: {
+                ticks: {
+                    color: this.tickColor,
+                },
+                type: "category",
+                title: {
+                    display: true,
+                    text: 'Year',
+                    color: this.axisTitleColor,
+                    font: {
+                        size: 16
+                    }
+                },
+            },
+            y: {
+                stacked: true,
+                ticks: {
+                    color: this.tickColor,
+                },
+                beginAtZero: true,
+                title: {
+                    display: true,
+                    text: 'Item Value',
+                    color: this.axisTitleColor,
+                    font: {
+                        size: 16
+                    }
+                }
+            }
+        }
+    }
+
+    updateChartColors() {
+        for (let i = 0; i < this.chart.data.datasets.length; i++) {
+            const dataset = this.chart.data.datasets[i]
+            const color = this.colorProvider.get(dataset.ICode)
+            dataset.borderColor = color
+            dataset.backgroundColor = color + "44"
+        }
+    }
+
+    setTheme(theme) {
+        if (theme !== "light") {
+            this.theme = "dark"
+            this.tickColor = "#bbb"
+            this.axisTitleColor = "#bbb"
+            this.titleColor = "#ccc"
+        } else {
+            this.theme = "light"
+            this.tickColor = "#444"
+            this.axisTitleColor = "#444"
+            this.titleColor = "#444"
+        }
+    }
+
+    async fetch(url) {
+        const response = await fetch(url)
+        try {
+            return response.json()
+        } catch (error) {
+            console.error('Error:', error)
+        }
+    }
+
+    update(data) {
+        console.log(data)
+        // this.chart.data = data
+        this.chart.data.datasets = data.data
+        this.chart.data.labels = data.labels
+        this.title.innerText = data.title
+        this.itemType = data.itemType
+        this.updateChartColors()
+        this.chart.options.scales.y.min = 0
+        this.chart.options.scales.y.max = 1
+        this.chart.update()
+    }
+
+
+    closeChartOptionsSidebar() {
+        this.chartOptions.classList.remove('active')
+        this.chartOptions.classList.add('inactive')
+        this.overlay.classList.remove('active')
+        this.overlay.classList.add('inactive')
+    }
+
+    openChartOptionsSidebar() {
+        this.chartOptions.classList.add('active')
+        this.chartOptions.classList.remove('inactive')
+        this.overlay.classList.remove('inactive')
+        this.overlay.classList.add('active')
+    }
+
+    toggleChartOptionsSidebar() {
+        if (this.chartOptions.classList.contains('active')) {
+            this.closeChartOptionsSidebar()
+        } else {
+            this.openChartOptionsSidebar()
+        }
+    }
+
+    dumpChartDataJSON(screenVisibility = true) {
+        const observations = this.chart.data.datasets.map(dataset => {
+            if (screenVisibility && dataset.hidden) {
+                return []
+            }
+            return dataset.data.map((_, i) => ({
+                "ItemCode": dataset.ICode,
+                "CountryCode": dataset.CCode,
+                "Score": dataset.scores[i],
+                "Value": dataset.values[i],
+                "Year": dataset.years[i]
+            }));
+        }).flat();
+        const jsonString = JSON.stringify(observations, null, 2);
+        const blob = new Blob([jsonString], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'item-panel-data.json';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+    }
+
+    dumpChartDataCSV(screenVisibility = true) {
+        const observations = this.chart.data.datasets.map(dataset => {
+            if (screenVisibility && dataset.hidden) {
+                return []
+            }
+            return dataset.data.map((_, i) => ({
+                "ItemCode": dataset.ICode,
+                "CountryCode": dataset.CCode,
+                "Score": dataset.scores[i].toString(),
+                "Value": dataset.values[i].toString(),
+                "Year": dataset.years[i].toString()
+            }));
+        }).flat();
+        const csvString = Papa.unparse(observations);
+        const blob = new Blob([csvString], { type: 'text/csv' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'item-panel-data.csv';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+    }
+
+    rigUnloadListener() {
+        window.addEventListener('beforeunload', () => {
+            window.observableStorage.setItem(
+                "openCountryChartDetails",
+                Array.from(this.chartOptions.querySelectorAll('.chart-options-details'))
+                    .filter(details => details.open)
+                    .map(details => details.classList[0])
+            )
+            window.observableStorage.setItem(
+                "chartOptionsStatus",
+                this.chartOptions.classList.contains('active') ? "active" : "inactive"
+            )
+        })
+    }
+
+    setYAxisScale(scale) {
+        this.yAxisScale = scale
+        const scaleType = scale.charAt(0).toUpperCase() + scale.slice(1)
+        let itemType = ""
+        if (this.itemType === "sspi") {
+            itemType = this.itemType.toUpperCase()
+        } else {
+            itemType = this.itemType.charAt(0).toUpperCase() + this.itemType.slice(1)
+        }
+        this.chart.options.scales.y.title.text = itemType + " " + scaleType 
+        let yMin = 0
+        let yMax = 1
+        for (let i = 0; i < this.chart.data.datasets.length; i++) {
+            const dataset = this.chart.data.datasets[i];
+            if (i == 0) {
+                yMin = (this.yAxisScale === "value") ? dataset.maxYValue : 0;
+                yMax = (this.yAxisScale === "value") ? dataset.maxYValue : 1;
+            }
+            dataset.parsing.yAxisKey = this.yAxisScale;
+            for (let j = 0; j < dataset.data.length; j++) {
+                if (this.yAxisScale === "value") {
+                    dataset.data[j] = dataset.value[j]
+                } else {
+                    dataset.data[j] = dataset.score[j]
+                }
+            }
+        }
+        this.chart.options.scales.y.min = yMin
+        this.chart.options.scales.y.max = yMax
+        this.chart.update()
+    }
+
+
+    toggleYAxisScale() {
+        if (this.yAxisScale === "score") {
+            this.setYAxisScale("value")
+        } else {
+            this.setYAxisScale("score")
+        }
+    }
+}

--- a/sspi_flask_app/client/static/charts/plugins/end-label-plugin.js
+++ b/sspi_flask_app/client/static/charts/plugins/end-label-plugin.js
@@ -1,6 +1,9 @@
 const endLabelPlugin = {
     id: 'endLabelPlugin',
-    afterDatasetsDraw(chart) {
+    defaults: {
+        labelField: 'CCode',   // dataset[field] to show
+    },
+    afterDatasetsDraw(chart, _args, opts) {
         const { ctx } = chart;
         for (let i = 0; i < chart.data.datasets.length; i++) {
             const dataset = chart.data.datasets[i];
@@ -16,7 +19,7 @@ const endLabelPlugin = {
                 }
             }
             if (!lastPoint) continue;
-            const value = dataset.CCode ?? '';
+            const value = dataset[opts.labelField] ?? '';
             ctx.save();
             ctx.font = 'bold 14px Arial';
             ctx.fillStyle = dataset.borderColor ?? '#000';

--- a/sspi_flask_app/client/templates/country-data.html
+++ b/sspi_flask_app/client/templates/country-data.html
@@ -1,5 +1,34 @@
 {% extends 'layout.html' %}
 
+{% block title %}
+    <title> {{ CountryCode | upper }} Data </title>
+{% endblock title %}
+
 {% block content %}
-<p> hello world </p>
+{% if error %}
+    <div class="alert alert-danger" role="alert">
+        <strong>Error:</strong> No Country {{ CountryCode }} found!
+    </div>
+{% else %}
+    <section class="chart-section" id="dynamic-data-section"></section>
+    <script>
+        window.addEventListener("load", (event) => {
+            window.observableStorage = new ObservableStorage();
+            window.SSPICharts = [
+                new CountryScoreChart(document.getElementById("dynamic-data-section"), "{{ CountryCode | upper}}", "SSPI", { colorProvider: SSPIColors }),
+            ];
+            const x = window.observableStorage.getItem('windowX');
+            const y = window.observableStorage.getItem('windowY');
+            
+            if (x !== null && y !== null) {
+              window.moveTo(parseInt(x), parseInt(y));
+            }
+        })
+        window.addEventListener('beforeunload', () => {
+          window.observableStorage.setItem('windowX', window.screenX);
+          window.observableStorage.setItem('windowY', window.screenY);
+        });
+    </script>
+{% endif %}
 {% endblock content %}
+


### PR DESCRIPTION
Skeleton for Country Pages now exists, but its basic functions for Chart Options layout should be inherited, not duplicated.
- **feat: Implemented sspi url to handle generic url stubs**
- **feat: Updated endLabelPlugin Now Takes Configuration Option 'labelField'**
- **feat: Implemented get_child_details method**
- **feat: Implemented /country/dynamic/stack route**
- **feat: Implemented country-data.html Route**
- **feat: Implemented CountryDataChart Basic Functionality**
