### PR TITLE
security: fix admin escalation, DoS, CSRF & input-validation findings

### DIFF
--- a/config.py
+++ b/config.py
@@ -13,9 +13,14 @@ class Config:
     FLASK_ENV = 'development'
     LOG_LEVEL = logging.INFO
     LOG_DIR = path.join(basedir, 'logs')
-    TESTING = True
+    # Secure default: only DevConfig/TestConfig opt into testing/login-disabled.
+    TESTING = False
     SECRET_KEY = environ['SECRET_KEY']
     RELOAD = False
+    # Global backstop on request body size (256 MB). Per-endpoint input bounds
+    # (utilities / customize) do the real work; this just stops absurd payloads
+    # from being buffered. Admin bulk /load dumps stay well under this.
+    MAX_CONTENT_LENGTH = 256 * 1024 * 1024
     STATIC_FOLDER = 'static'
     TEMPLATES_FOLDER = 'templates'
     ASSETS_DEBUG = False
@@ -34,8 +39,18 @@ class Config:
 class ProdConfig(Config):
     FLASK_ENV = 'production'
     DEBUG = False
-    LOG_LEVEL = logging.DEBUG
+    LOG_LEVEL = logging.INFO
     TESTING = False
+    # Cookie hardening (F5): only send cookies over HTTPS, keep them out of JS,
+    # and constrain cross-site sending. The remember-me cookie lives 30 days, so
+    # protecting it in transit and against CSRF matters.
+    SESSION_COOKIE_SECURE = True
+    SESSION_COOKIE_HTTPONLY = True
+    SESSION_COOKIE_SAMESITE = "Lax"
+    REMEMBER_COOKIE_SECURE = True
+    REMEMBER_COOKIE_HTTPONLY = True
+    REMEMBER_COOKIE_SAMESITE = "Lax"
+    PREFERRED_URL_SCHEME = "https"
 
 
 class DevConfig(Config):

--- a/sspi_flask_app/api/core/customize.py
+++ b/sspi_flask_app/api/core/customize.py
@@ -65,6 +65,11 @@ def compute_metadata_counts(metadata: list) -> dict:
     dataset_codes = set()
 
     for item in metadata:
+        # Defensive: skip malformed items here (strict validation/rejection
+        # happens in create_config -> validate_metadata). Avoids a 500 when an
+        # item is not a dict or DatasetCodes is not a list. (Audit finding F16.)
+        if not isinstance(item, dict):
+            continue
         item_type = item.get("ItemType", "")
         if item_type == "Pillar":
             counts["pillar_count"] += 1
@@ -72,9 +77,11 @@ def compute_metadata_counts(metadata: list) -> dict:
             counts["category_count"] += 1
         elif item_type == "Indicator":
             counts["indicator_count"] += 1
-            # Count datasets from indicators
-            for code in item.get("DatasetCodes", []):
-                dataset_codes.add(code)
+            # Count datasets from indicators (guard against non-list DatasetCodes)
+            dataset_codes_field = item.get("DatasetCodes", [])
+            if isinstance(dataset_codes_field, list):
+                for code in dataset_codes_field:
+                    dataset_codes.add(code)
 
     counts["dataset_count"] = len(dataset_codes)
     return counts
@@ -374,8 +381,8 @@ def save_configuration():
     except LimitExceededError as e:
         logger.warning(f"User {current_user.username} exceeded config limit: {str(e)}")
         return jsonify({"success": False, "error": str(e)}), 429
-    except ValueError as e:
-        logger.error(f"Validation error saving configuration: {str(e)}")
+    except (ValueError, InvalidDocumentFormatError) as e:
+        logger.warning(f"Validation error saving configuration: {str(e)}")
         return jsonify({"success": False, "error": str(e)}), 400
     except Exception as e:
         import traceback

--- a/sspi_flask_app/api/core/dashboard.py
+++ b/sspi_flask_app/api/core/dashboard.py
@@ -641,6 +641,7 @@ def get_static_stacked_sspi():
 
 @dashboard_bp.route("/utilities/extrapolate/backward/<int:year>", methods=["POST"])
 @csrf.exempt  # API endpoint accessed programmatically (CLI/scripts), not browser forms
+@admin_required
 def do_backward_extrapolate(year: int):
     """
     Extrapolate backward missing data for a given indicator
@@ -662,6 +663,7 @@ def do_backward_extrapolate(year: int):
 
 @dashboard_bp.route("/utilities/extrapolate/forward/<int:year>", methods=["POST"])
 @csrf.exempt  # API endpoint accessed programmatically (CLI/scripts), not browser forms
+@admin_required
 def do_forward_extrapolate(year: int):
     """
     Extrapolate backward missing data for a given indicator
@@ -683,6 +685,7 @@ def do_forward_extrapolate(year: int):
 
 @dashboard_bp.route("/utilities/interpolate/linear", methods=["POST"])
 @csrf.exempt  # API endpoint accessed programmatically (CLI/scripts), not browser forms
+@admin_required
 def do_linear_interpolate():
     """
     Extrapolate backward missing data for a given indicator
@@ -701,6 +704,7 @@ def do_linear_interpolate():
 
 @dashboard_bp.route("/utilities/panel/levels", methods=["POST"])
 @csrf.exempt  # API endpoint accessed programmatically (CLI/scripts), not browser forms
+@admin_required
 def find_panel_levels():
     """
     Prepare panel data for plotting
@@ -732,6 +736,7 @@ def find_panel_levels():
 
 @dashboard_bp.route("/utilities/panel/plot", methods=["POST"])
 @csrf.exempt  # API endpoint accessed programmatically (CLI/scripts), not browser forms
+@admin_required
 def prepare_panel_data():
     """
     Prepare panel data for plotting

--- a/sspi_flask_app/api/core/dataset.py
+++ b/sspi_flask_app/api/core/dataset.py
@@ -6,7 +6,7 @@ from sspi_flask_app.api.core.datasets import (
     dataset_cleaner_registry,
     dataset_collector_registry)
 
-from sspi_flask_app.auth.decorators import admin_required
+from sspi_flask_app.auth.decorators import admin_required, require_bearer_for_writes
 from sspi_flask_app.api.resources.utilities import (
     check_raw_document_set_coverage,
     parse_json,
@@ -23,6 +23,12 @@ dataset_bp = Blueprint(
     template_folder="templates",
     static_folder="static",
 )
+
+# /collect is CSRF-exempt for CLI (Bearer) access; require Bearer auth on POST so
+# an ambient admin session cookie can't be used to forge a cross-site collect
+# (CSRF). GET (the confirmation form/info) is unaffected. (Audit finding F7.)
+dataset_bp.before_request(require_bearer_for_writes)
+
 
 @dataset_bp.route("/collect/<series_code>", methods=["GET", "POST"])
 @csrf.exempt  # API endpoint accessed programmatically (CLI/scripts), not browser forms

--- a/sspi_flask_app/api/core/sspi/__init__.py
+++ b/sspi_flask_app/api/core/sspi/__init__.py
@@ -2,7 +2,7 @@ import time
 from flask import Blueprint, current_app, Response, session
 from flask_login import login_required, current_user, login_user
 from sspi_flask_app.models.database import sspi_metadata
-from sspi_flask_app.auth.decorators import admin_required
+from sspi_flask_app.auth.decorators import admin_required, require_bearer_for_writes
 
 compute_bp = Blueprint(
     "compute_bp",
@@ -19,6 +19,14 @@ impute_bp = Blueprint(
     static_folder="static",
     url_prefix="/impute",
 )
+
+# These blueprints are CSRF-exempt (programmatic CLI access via Bearer token).
+# Require Bearer auth on state-changing requests so an ambient session cookie
+# cannot be used to forge cross-site writes (CSRF). Internal compute/impute
+# dispatch calls view functions directly (not via HTTP), so this before_request
+# guard does not affect it. (Audit finding F7.)
+compute_bp.before_request(require_bearer_for_writes)
+impute_bp.before_request(require_bearer_for_writes)
 
 _COMPUTE_REGISTRY = {}
 _IMPUTE_REGISTRY = {}

--- a/sspi_flask_app/api/resources/metadata_validator.py
+++ b/sspi_flask_app/api/resources/metadata_validator.py
@@ -590,7 +590,13 @@ def canonicalize_metadata(metadata: list[dict]) -> list[dict]:
     return [canonicalize_item(item) for item in canonical]
 
 
-def canonicalize_item(item: dict, filter_fields: bool = True) -> dict:
+# Maximum nesting depth when canonicalizing metadata for hashing. Real configs
+# are shallow; this bounds recursion so a deeply-nested attacker payload raises a
+# controlled error instead of consuming the stack/CPU (RecursionError). (F15.)
+MAX_CANONICALIZE_DEPTH = 64
+
+
+def canonicalize_item(item: dict, filter_fields: bool = True, _depth: int = 0) -> dict:
     """
     Normalize a single metadata item for consistent hashing.
 
@@ -602,7 +608,11 @@ def canonicalize_item(item: dict, filter_fields: bool = True) -> dict:
     Args:
         item: Metadata item dictionary
         filter_fields: If True, only include fields in CONFIG_HASH_FIELDS
+        _depth: Internal recursion-depth counter (do not set directly)
     """
+    if _depth > MAX_CANONICALIZE_DEPTH:
+        raise ValueError("Metadata nesting exceeds the maximum allowed depth")
+
     canonical = {}
 
     for key in sorted(item.keys()):
@@ -610,13 +620,15 @@ def canonicalize_item(item: dict, filter_fields: bool = True) -> dict:
         if filter_fields and key not in CONFIG_HASH_FIELDS:
             continue
         value = item[key]
-        canonical[key] = canonicalize_value(value)
+        canonical[key] = canonicalize_value(value, _depth=_depth + 1)
 
     return canonical
 
 
-def canonicalize_value(value: Any) -> Any:
-    """Recursively canonicalize a value."""
+def canonicalize_value(value: Any, _depth: int = 0) -> Any:
+    """Recursively canonicalize a value (depth-bounded)."""
+    if _depth > MAX_CANONICALIZE_DEPTH:
+        raise ValueError("Metadata nesting exceeds the maximum allowed depth")
     if value is None:
         return None
     elif isinstance(value, bool):
@@ -636,9 +648,9 @@ def canonicalize_value(value: Any) -> Any:
             return sorted(value)
         else:
             # Preserve order for numeric and mixed lists (like TreeIndex)
-            return [canonicalize_value(v) for v in value]
+            return [canonicalize_value(v, _depth=_depth + 1) for v in value]
     elif isinstance(value, dict):
-        return canonicalize_item(value)
+        return canonicalize_item(value, _depth=_depth + 1)
     else:
         # Fallback: convert to string
         return str(value)

--- a/sspi_flask_app/api/resources/query_builder.py
+++ b/sspi_flask_app/api/resources/query_builder.py
@@ -170,22 +170,38 @@ def build_mongo_query(raw_query_input, database=None):
         if country_codes:
             mongo_query["CountryCode"] = {"$in": list(country_codes)}
 
+        # Reasonable bounds for SSPI year data. Used to reject absurd ranges that
+        # would otherwise expand into billions of integers and OOM the worker
+        # before any DB call, and to turn bad input into a clean 400. (F2/F12)
+        MIN_YEAR, MAX_YEAR = 1900, 2100
+
         # Handle Year filtering with time period expansion
         years = set()
 
         # Add individual years
         if raw_query_input["Year"]:
-            years.update([int(y) for y in raw_query_input["Year"]])
+            try:
+                years.update(int(y) for y in raw_query_input["Year"])
+            except (TypeError, ValueError):
+                raise InvalidQueryError("Invalid Query: 'Year' must be numeric")
 
         # Expand and add time periods
         if raw_query_input["TimePeriod"]:
             expanded_years = expand_time_periods(raw_query_input["TimePeriod"])
             years.update(expanded_years)
 
-        # Add year ranges
+        # Add year ranges (bounded to avoid unbounded range() expansion)
         if raw_query_input["YearRangeStart"] and raw_query_input["YearRangeEnd"]:
-            start_year = int(raw_query_input["YearRangeStart"])
-            end_year = int(raw_query_input["YearRangeEnd"])
+            try:
+                start_year = int(raw_query_input["YearRangeStart"])
+                end_year = int(raw_query_input["YearRangeEnd"])
+            except (TypeError, ValueError):
+                raise InvalidQueryError("Invalid Query: year range must be numeric")
+            if not (MIN_YEAR <= start_year <= end_year <= MAX_YEAR):
+                raise InvalidQueryError(
+                    "Invalid Query: year range must satisfy "
+                    f"{MIN_YEAR} <= start <= end <= {MAX_YEAR}"
+                )
             years.update(range(start_year, end_year + 1))
 
         if years:

--- a/sspi_flask_app/api/resources/validators.py
+++ b/sspi_flask_app/api/resources/validators.py
@@ -28,15 +28,27 @@ def validate_data_query(raw_query_input:dict):
 
     def validate_query_safety(raw_query_input):
         """
-        Uses _is_safe to check that the query parameters are safe
+        Uses _is_safe to check that the query parameter VALUES are safe.
+
+        Previously this iterated ``enumerate(raw_query_input)``, which for a dict
+        yields ``(index, key)`` -- so ``value`` was always a static field name and
+        the user-supplied values were never inspected, silently disabling the
+        filter. We now validate each value (and each item of list-valued params)
+        and reject operator objects (e.g. ``{"$ne": null}``). (Audit finding F6.)
         """
         if len(raw_query_input.keys()) > 200:
             raise InvalidQueryError("Invalid Query: Too many parameters passed")
-        for key, value in enumerate(raw_query_input):
-            if (type(value) is str or type(value) is int) and not _is_safe(value):
-                raise InvalidQueryError(f"Invalid Query: Unsafe Parameters Passed for {key}: {value}")
-            elif type(value) is list and any([not _is_safe(item) for item in value]):
-                raise InvalidQueryError(f"Invalid Query: Unsafe Parameters Passed for list {key}")
+        for key, value in raw_query_input.items():
+            items = value if isinstance(value, list) else [value]
+            for item in items:
+                if isinstance(item, dict):
+                    raise InvalidQueryError(
+                        f"Invalid Query: operator objects are not allowed for '{key}'"
+                    )
+                if not _is_safe(item):
+                    raise InvalidQueryError(
+                        f"Invalid Query: Unsafe Parameters Passed for '{key}': {item}"
+                    )
         return raw_query_input
 
     return validate_query_safety(raw_query_input)

--- a/sspi_flask_app/auth/decorators.py
+++ b/sspi_flask_app/auth/decorators.py
@@ -205,3 +205,25 @@ def owner_or_admin_required(f):
         return f(*args, **kwargs)
 
     return decorated_function
+
+
+def require_bearer_for_writes():
+    """Blueprint ``before_request`` guard for CSRF-exempt programmatic endpoints.
+
+    State-changing requests (POST/PUT/PATCH/DELETE) must authenticate with a
+    Bearer API key rather than an ambient session cookie. Browsers cannot attach
+    an ``Authorization`` header on cross-site requests, so requiring one makes
+    CSRF impossible on these CSRF-exempt admin endpoints (compute / impute /
+    collect) while leaving the CLI (which sends Bearer) and any GET form/info
+    routes unaffected. (Audit finding F7.)
+
+    Register with ``blueprint.before_request(require_bearer_for_writes)``.
+    """
+    if request.method in ("POST", "PUT", "PATCH", "DELETE"):
+        auth_header = request.headers.get("Authorization", "")
+        if not auth_header.startswith("Bearer "):
+            return jsonify({
+                "error": "This operation requires Bearer API-key authentication.",
+                "message": "State-changing requests to this endpoint must send an "
+                           "Authorization: Bearer <api_key> header (use the CLI).",
+            }), 403

--- a/sspi_flask_app/auth/routes.py
+++ b/sspi_flask_app/auth/routes.py
@@ -88,17 +88,17 @@ class UpdatePasswordForm(FlaskForm):
         label="Username",
     )
     oldpassword = PasswordField(
-        validators=[InputRequired(), Length(min=4, max=20)],
+        validators=[InputRequired(), Length(min=4, max=128)],
         render_kw={"placeholder": "Old Password"},
         label="Old Password",
     )
     newpassword = PasswordField(
-        validators=[InputRequired(), Length(min=4, max=20)],
+        validators=[InputRequired(), Length(min=8, max=128)],
         render_kw={"placeholder": "New Password"},
         label="New Password",
     )
     newpasswordconfirm = PasswordField(
-        validators=[InputRequired(), Length(min=4, max=20)],
+        validators=[InputRequired(), Length(min=8, max=128)],
         render_kw={"placeholder": "Confirm Password"},
         label="Confirm Password",
     )
@@ -162,7 +162,7 @@ class LoginForm(FlaskForm):
         label="Username",
     )
     password = PasswordField(
-        validators=[InputRequired(), Length(min=4, max=20)],
+        validators=[InputRequired(), Length(min=4, max=128)],
         render_kw={"placeholder": "Password"},
         label="Password",
     )
@@ -177,7 +177,7 @@ class UserLoginForm(FlaskForm):
         label="Username",
     )
     password = PasswordField(
-        validators=[InputRequired(), Length(min=4, max=20)],
+        validators=[InputRequired(), Length(min=4, max=128)],
         render_kw={"placeholder": "Password"},
         label="Password",
     )
@@ -206,7 +206,7 @@ def user_login():
         )
     login_user(
         user,
-        remember=bool(login_form.remember_me),
+        remember=login_form.remember_me.data,
         duration=app.config["REMEMBER_COOKIE_DURATION"],
     )
 
@@ -253,7 +253,7 @@ def admin_login():
         )
     login_user(
         user,
-        remember=bool(login_form.remember_me),
+        remember=login_form.remember_me.data,
         duration=app.config["REMEMBER_COOKIE_DURATION"],
     )
     if not next_url:

--- a/sspi_flask_app/auth/routes.py
+++ b/sspi_flask_app/auth/routes.py
@@ -14,11 +14,10 @@ from sspi_flask_app.models.usermodel import User
 from sspi_flask_app.models.errors import InvalidDocumentFormatError
 from sspi_flask_app.models.database import sspi_user_data
 from sspi_flask_app import login_manager, flask_bcrypt
+from sspi_flask_app.auth.decorators import admin_required
 
 from flask_login import (
-    fresh_login_required,
     login_user,
-    login_required,
     logout_user,
     current_user,
 )
@@ -307,7 +306,7 @@ def register():
 
 
 @auth_bp.route("/auth/register-admin", methods=["GET", "POST"])
-@fresh_login_required
+@admin_required
 def register_admin():
     """Admin-only registration - can create users with any role"""
     register_form = RegisterForm()
@@ -368,7 +367,7 @@ def check_email():
 
 
 @auth_bp.route("/auth/clear", methods=["GET"])
-@fresh_login_required
+@admin_required
 def clear():
     if not app.config["DEBUG"]:
         return Response("This route is only available in DEBUG mode", status=403)
@@ -377,14 +376,17 @@ def clear():
 
 
 @auth_bp.route("/auth/query", methods=["GET"])
-@fresh_login_required
+@admin_required
 def query():
+    # SECURITY: never expose API keys here. API keys are Bearer credentials
+    # that authenticate as their owner, so leaking them (previously to any
+    # fresh-logged-in non-admin) allowed user->admin escalation. Admin-only
+    # listing with secrets stripped.
     users = User.get_all_users()
     user_info = []
     for user in users:
         user_info.append({
             'username': user.username,
-            'apikey': user.apikey,
             'id': user.id
         })
     return jsonify(user_info), 200

--- a/sspi_flask_app/auth/routes.py
+++ b/sspi_flask_app/auth/routes.py
@@ -107,7 +107,14 @@ class UpdatePasswordForm(FlaskForm):
 
 class RegisterForm(FlaskForm):
     username = StringField(
-        validators=[InputRequired(), Length(min=6, max=20)],
+        validators=[
+            InputRequired(),
+            Length(min=6, max=20),
+            Regexp(
+                r"^[A-Za-z0-9_]+$",
+                message="Username may only contain letters, numbers, and underscores.",
+            ),
+        ],
         render_kw={"placeholder": "Username"},
         label="Username",
     )

--- a/sspi_flask_app/auth/routes.py
+++ b/sspi_flask_app/auth/routes.py
@@ -13,7 +13,7 @@ from flask import (
 from sspi_flask_app.models.usermodel import User
 from sspi_flask_app.models.errors import InvalidDocumentFormatError
 from sspi_flask_app.models.database import sspi_user_data
-from sspi_flask_app import login_manager, flask_bcrypt
+from sspi_flask_app import login_manager, flask_bcrypt, limiter
 from sspi_flask_app.auth.decorators import admin_required
 
 from flask_login import (
@@ -36,6 +36,33 @@ auth_bp = Blueprint(
 )
 
 login_manager.login_view = "auth_bp.user_login"
+
+# Strict per-route limits for credential-handling endpoints. The global limiter
+# default (50000/hr) is far too permissive to stop online password guessing, so
+# authentication and account-existence endpoints get their own tight buckets
+# (keyed by remote address). Applied to POST only so rendering the form (GET)
+# is not throttled. (Audit finding F4.)
+AUTH_RATE_LIMIT = "10 per minute;100 per hour"
+
+# Pre-computed bcrypt hash used to equalize response time when the supplied
+# username does not exist, so that "unknown user" and "wrong password" take the
+# same wall-clock time and cannot be distinguished by timing. (Audit finding F11.)
+_DUMMY_PASSWORD_HASH = flask_bcrypt.generate_password_hash(
+    secrets.token_hex(16)
+).decode("utf-8")
+
+
+def verify_user_password(user, password):
+    """Verify a password, always running bcrypt to avoid a timing oracle.
+
+    When ``user`` is ``None`` we still perform a bcrypt comparison against a
+    throwaway hash so the response time matches the wrong-password path, then
+    return ``False``.
+    """
+    if user is None:
+        flask_bcrypt.check_password_hash(_DUMMY_PASSWORD_HASH, password)
+        return False
+    return flask_bcrypt.check_password_hash(user.password, password)
 
 
 @login_manager.user_loader
@@ -154,6 +181,7 @@ class UserLoginForm(FlaskForm):
 
 
 @auth_bp.route("/login", methods=["GET", "POST"])
+@limiter.limit(AUTH_RATE_LIMIT, methods=["POST"])
 def user_login():
     next_url = request.args.get("next", None)
     if current_user.is_authenticated:
@@ -162,9 +190,8 @@ def user_login():
     if not login_form.validate_on_submit():
         return render_template("user-login.html", form=login_form, title="Login")
     user = User.find_by_username(login_form.username.data)
-    if user is None or not flask_bcrypt.check_password_hash(
-        user.password, login_form.password.data
-    ):
+    password_ok = verify_user_password(user, login_form.password.data)
+    if user is None or not password_ok:
         flash("Invalid username or password")
         return render_template(
             "user-login.html",
@@ -191,6 +218,7 @@ def user_login():
 
 
 @auth_bp.route("/admin", methods=["GET", "POST"])
+@limiter.limit(AUTH_RATE_LIMIT, methods=["POST"])
 def admin_login():
     next_url = request.args.get("next", None)
     if current_user.is_authenticated:
@@ -199,9 +227,8 @@ def admin_login():
     if not login_form.validate_on_submit():
         return render_template("login.html", form=login_form, title="Admin Login")
     user = User.find_by_username(login_form.username.data)
-    if user is None or not flask_bcrypt.check_password_hash(
-        user.password, login_form.password.data
-    ):
+    password_ok = verify_user_password(user, login_form.password.data)
+    if user is None or not password_ok:
         flash("Invalid username or password")
         return render_template(
             "login.html",
@@ -234,6 +261,7 @@ def admin_login():
 
 
 @auth_bp.route('/auth/key', methods=['GET', 'POST'])
+@limiter.limit(AUTH_RATE_LIMIT, methods=["POST"])
 def apikey_web():
     if current_user.is_authenticated:
         return Response(current_user.apikey, 200, mimetype='text/plain')
@@ -243,8 +271,8 @@ def apikey_web():
                                form=form,
                                title="Retrieve API Key")
     user = User.find_by_username(form.username.data)
-    if user is None or not flask_bcrypt.check_password_hash(
-            user.password, form.password.data):
+    password_ok = verify_user_password(user, form.password.data)
+    if user is None or not password_ok:
         flash("Invalid username or password")
         return render_template('apikey.html',
                                form=form,

--- a/sspi_flask_app/auth/routes.py
+++ b/sspi_flask_app/auth/routes.py
@@ -44,6 +44,11 @@ login_manager.login_view = "auth_bp.user_login"
 # is not throttled. (Audit finding F4.)
 AUTH_RATE_LIMIT = "10 per minute;100 per hour"
 
+# Account-existence oracles (username/email availability). Looser than the login
+# bucket so live form validation keeps working, but tight enough to stop bulk
+# enumeration (vs. the useless 50000/hr global default). (Audit finding F10.)
+ENUM_RATE_LIMIT = "30 per minute;300 per hour"
+
 # Pre-computed bcrypt hash used to equalize response time when the supplied
 # username does not exist, so that "unknown user" and "wrong password" take the
 # same wall-clock time and cannot be distinguished by timing. (Audit finding F11.)
@@ -358,9 +363,13 @@ def register_admin():
 
 
 @auth_bp.route("/auth/check-username", methods=["POST"])
+@limiter.limit(ENUM_RATE_LIMIT)
 def check_username():
     """API endpoint to check if username is available"""
-    username = request.json.get("username", "").strip()
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict) or not isinstance(data.get("username", ""), str):
+        return jsonify({"available": False, "message": "Invalid request"}), 400
+    username = data.get("username", "").strip()
 
     if not username:
         return jsonify({"available": False, "message": "Username is required"})
@@ -375,9 +384,13 @@ def check_username():
 
 
 @auth_bp.route("/auth/check-email", methods=["POST"])
+@limiter.limit(ENUM_RATE_LIMIT)
 def check_email():
     """API endpoint to check if email is available"""
-    email = request.json.get("email", "").strip()
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict) or not isinstance(data.get("email", ""), str):
+        return jsonify({"available": False, "message": "Invalid request"}), 400
+    email = data.get("email", "").strip()
 
     if not email:
         return jsonify({"available": False, "message": "Email is required"})

--- a/sspi_flask_app/client/templates/layout.html
+++ b/sspi_flask_app/client/templates/layout.html
@@ -74,7 +74,7 @@
         <script>
           document.addEventListener('DOMContentLoaded', function() {
             {% for message in messages %}
-              window.notifications.info('{{ message | safe }}');
+              window.notifications.info({{ message | tojson }});
             {% endfor %}
           });
         </script>

--- a/sspi_flask_app/models/database/sspi_custom_user_structure.py
+++ b/sspi_flask_app/models/database/sspi_custom_user_structure.py
@@ -1,6 +1,7 @@
 from sspi_flask_app.models.database.mongo_wrapper import MongoWrapper
 from sspi_flask_app.models.errors import InvalidDocumentFormatError, LimitExceededError
 from datetime import datetime, timezone
+import json
 import secrets
 import re
 
@@ -33,6 +34,12 @@ class SSPICustomUserStructure(MongoWrapper):
     """
 
     MAX_CONFIGS_PER_USER = 100
+    # Per-config metadata bounds. The full SSPI structure is a few hundred items,
+    # so these are generous; they exist to stop storage-exhaustion via padded or
+    # runaway configs (there is no per-field whitelist, so arbitrary keys would
+    # otherwise be stored verbatim up to MongoDB's 16 MB doc limit). (Finding F9.)
+    MAX_METADATA_ITEMS = 5000
+    MAX_METADATA_BYTES = 4 * 1024 * 1024  # 4 MB serialized
 
     def validate_document_format(self, document: dict, document_number: int = 0):
         """
@@ -141,6 +148,27 @@ class SSPICustomUserStructure(MongoWrapper):
         if not isinstance(metadata, list):
             raise InvalidDocumentFormatError(
                 f"'metadata' must be a list (document {document_number})"
+            )
+
+        # Bound item count and total serialized size to prevent storage
+        # exhaustion via oversized/padded configs. (Audit finding F9.)
+        if len(metadata) > self.MAX_METADATA_ITEMS:
+            raise LimitExceededError(
+                f"Configuration metadata exceeds the maximum of "
+                f"{self.MAX_METADATA_ITEMS} items"
+            )
+        try:
+            serialized_bytes = len(
+                json.dumps(metadata, default=str).encode("utf-8")
+            )
+        except (TypeError, ValueError):
+            raise InvalidDocumentFormatError(
+                f"'metadata' must be JSON-serializable (document {document_number})"
+            )
+        if serialized_bytes > self.MAX_METADATA_BYTES:
+            raise LimitExceededError(
+                f"Configuration metadata exceeds the maximum size of "
+                f"{self.MAX_METADATA_BYTES // (1024 * 1024)} MB"
             )
 
         # Basic structure validation - each item should be a dict with ItemType

--- a/tests/unit/security/test_query_sanitizer.py
+++ b/tests/unit/security/test_query_sanitizer.py
@@ -1,0 +1,58 @@
+"""Regression tests for the query input sanitizer (audit finding F6).
+
+The sanitizer previously iterated ``enumerate(dict)``, so it inspected field
+names instead of user values and never actually filtered anything. These tests
+lock in that VALUES are validated and that NoSQL operator objects are rejected.
+"""
+import pytest
+
+from sspi_flask_app.api.resources.validators import validate_data_query
+from sspi_flask_app.models.errors import InvalidQueryError
+
+
+def _base_query(**overrides):
+    query = {
+        "SeriesCodes": [],
+        "CountryCode": [],
+        "CountryGroup": None,
+        "Year": [],
+        "TimePeriod": [],
+        "YearRangeStart": None,
+        "YearRangeEnd": None,
+    }
+    query.update(overrides)
+    return query
+
+
+def test_accepts_clean_values():
+    query = _base_query(
+        SeriesCodes=["BIODIV", "REDLST"], CountryGroup="SSPI67", Year=["2018"]
+    )
+    assert validate_data_query(query) is query
+
+
+def test_rejects_operator_object_scalar():
+    """A dict value like {"$ne": null} must be rejected, not silently passed."""
+    with pytest.raises(InvalidQueryError):
+        validate_data_query(_base_query(CountryGroup={"$ne": None}))
+
+
+def test_rejects_operator_object_inside_list():
+    with pytest.raises(InvalidQueryError):
+        validate_data_query(_base_query(CountryCode=[{"$ne": None}]))
+
+
+def test_rejects_unsafe_characters():
+    with pytest.raises(InvalidQueryError):
+        validate_data_query(_base_query(CountryGroup="a;b|c"))
+
+
+def test_rejects_regex_metacharacters():
+    """Regex metacharacters previously reached a Mongo $regex unfiltered."""
+    with pytest.raises(InvalidQueryError):
+        validate_data_query(_base_query(CountryGroup=".*"))
+
+
+def test_rejects_too_many_parameters():
+    with pytest.raises(InvalidQueryError):
+        validate_data_query({f"k{i}": "v" for i in range(201)})

--- a/tests/unit/security/test_year_range_bounds.py
+++ b/tests/unit/security/test_year_range_bounds.py
@@ -1,0 +1,57 @@
+"""Regression tests for year-range bounds in build_mongo_query (findings F2/F12).
+
+An unbounded YearRange (e.g. 0..2_000_000_000) previously expanded into billions
+of integers via range() before any DB call, OOM-killing the worker; non-numeric
+year input raised an uncaught 500. These must now be clean InvalidQueryError.
+"""
+import pytest
+
+from sspi_flask_app.api.resources.query_builder import build_mongo_query
+from sspi_flask_app.models.errors import InvalidQueryError
+
+
+def _year_query(**overrides):
+    query = {
+        "SeriesCodes": [],
+        "CountryCode": [],
+        "CountryGroup": None,
+        "Year": [],
+        "TimePeriod": [],
+        "YearRangeStart": None,
+        "YearRangeEnd": None,
+    }
+    query.update(overrides)
+    return query
+
+
+def test_valid_year_range_expands():
+    mongo_query = build_mongo_query(
+        _year_query(YearRangeStart="2000", YearRangeEnd="2005"), database=None
+    )
+    assert set(mongo_query["Year"]["$in"]) == {2000, 2001, 2002, 2003, 2004, 2005}
+
+
+def test_rejects_unbounded_year_range():
+    with pytest.raises(InvalidQueryError):
+        build_mongo_query(
+            _year_query(YearRangeStart="0", YearRangeEnd="2000000000"), database=None
+        )
+
+
+def test_rejects_reversed_year_range():
+    with pytest.raises(InvalidQueryError):
+        build_mongo_query(
+            _year_query(YearRangeStart="2020", YearRangeEnd="2000"), database=None
+        )
+
+
+def test_rejects_nonnumeric_year():
+    with pytest.raises(InvalidQueryError):
+        build_mongo_query(_year_query(Year=["abc"]), database=None)
+
+
+def test_rejects_nonnumeric_year_range():
+    with pytest.raises(InvalidQueryError):
+        build_mongo_query(
+            _year_query(YearRangeStart="x", YearRangeEnd="y"), database=None
+        )


### PR DESCRIPTION
Implements fixes for the security audit of the SSPI Flask app. Built on `cs/integration` so it composes with the custom-scoring merge. Full report: `SECURITY_AUDIT.md` (on this branch).

## Highlights
- **CRITICAL — user→admin escalation closed.** `/auth/query` was guarded only by `@fresh_login_required` and returned every user's plaintext `apikey`; since API keys are Bearer credentials, any self-registered user could harvest an admin key and act as admin. Now `@admin_required` and the apikey is no longer returned.

## Fixes (12 atomic commits)
| Findings | Change |
|---|---|
| **F1 / F18** | `/auth/query` + `/auth/register-admin` (+`/auth/clear`) require `@admin_required`; apikey removed from `/auth/query` |
| F4 / F11 | per-route rate limits on `/login` `/admin` `/auth/key`; constant-time bcrypt for unknown usernames |
| F10 / F13 | rate-limit + type-validate `/auth/check-username|email` (no more 500 on non-string JSON) |
| F14 / F19 | remember-me honors the checkbox (`.data`); login password cap 20→128 |
| F17 | flash messages via `| tojson` (was `| safe`); registration username whitelist |
| F5 | ProdConfig Secure/HttpOnly/SameSite cookies, `TESTING=False` default, `MAX_CONTENT_LENGTH`, prod `LOG_LEVEL=INFO` |
| F6 | query sanitizer validates VALUES (was iterating dict keys via `enumerate`); rejects operator objects |
| F2 / F12 | year ranges bounded (1900–2100, ≤200 span) + numeric validation → clean 400 instead of OOM/500 |
| F8 | `@admin_required` on the 5 `/utilities/*` POST endpoints (closes anon DoS + anon panel-data wipe) |
| F7 | Bearer-only guard on compute/impute/collect writes — CSRF impossible, CLI unaffected |
| F9 / F15 / F16 | metadata size/count caps, canonicalize depth limit, defensive `DatasetCodes` |

**F3** (unbounded scoring threads/jobs) was already resolved by the merged `cs/jobstore` lane (Mongo job store + TTL + per-user/global concurrency caps); no further change needed.

## Tests
- 11 new pure-unit regression tests (F6 sanitizer, F2/F12 year-range): all pass.
- Full suite: **976 passed**. The 69 errors are the **pre-existing `cs/security` C2 deploy risk** (`DuplicateKey` building the unique cache index at startup) — reproduces identically on the untouched `cs/integration` base; fix by dropping/deduping `sspi_custom_item_data` / `sspi_custom_panel_data` before deploy. The 1 failure is environment-only (`SSPI_APIKEY` unset in CI worktree).

## Deferred (flagged, not dropped)
- **API-key hashing-at-rest** (F1 deeper hardening): needs a key-rotation migration and affects `/auth/token` retrieval + CLI; the exploit is already closed by gating `/auth/query`.
- **MAX_CONTENT_LENGTH** set to 256 MB (generous) so admin `/load` bulk dumps still work; per-endpoint bounds (F8/F9) do the real limiting.

## Caveat
This branch inherits `cs/integration`'s `documentation` submodule pointer (`ef9fb4c`), which is not yet pushed to the submodule remote — that ref will be dangling until the cs team pushes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)