### PR TITLE
perf: Tier 1 hot-path optimizations (logic-preserving)

### DIFF
--- a/docs/python-performance-audit.md
+++ b/docs/python-performance-audit.md
@@ -1,0 +1,143 @@
+# Python Performance Audit
+
+**Date:** 2026-06-26
+**Scope:** ~30,000 LOC of production Python in `sspi_flask_app/`, `cli/`, `scripts/`, `connector/` (tests excluded).
+**Method:** 14 parallel audit agents, each reading its assigned files in full and applying a shared checklist of *logic-preserving* optimizations (no behavior, output, ordering, or error-semantics changes). Findings deduplicated and prioritized below.
+
+**Impact tags:** `HOT` = per web request / per country-year cell · `WARM` = per data-build or CLI run · `COLD` = rare/startup.
+
+## Verified facts used throughout
+
+- `MongoWrapper.find()` / `.aggregate()` return **materialized Python lists**, not cursors.
+- `count_documents()` exists (`mongo_wrapper.py:45`).
+- `sspi_metadata` accessors (`item_codes`, `dataset_codes`, `get_*_detail`, `country_group`, `get_goalposts`) each issue an **uncached** `find_one`/`find`.
+
+---
+
+## Tier 1 — HOT, high-confidence, drop-in (highest value)
+
+Runs on user-facing requests; pure local edits.
+
+**A. Stop counting by fetching every document**
+- `client/routes.py:87` — `len(list(find(...)))` → `count_documents(same query)`
+- `dashboard.py:2345-2350` — same; also drop the redundant `list()` (preserve empty→`None` branch)
+
+**B. Drop `list()` around already-materialized `find()`/`aggregate()`**
+- `dashboard.py:157, 441, 1059`
+- `client/routes.py:72, 113, 140, 167`
+- `delete.py:197` (COLD, admin)
+- `sus/ghg/coalpw.py:126`, `sus/nrg/altnrg.py:142` (WARM — `list(x) + y` → `x + y`)
+
+**C. `sorted(...)[0]` → `max(..., key=...)`** (stable sort ⇒ identical element)
+- `dashboard.py:2230, 2265, 2300, 2336`
+- `client/routes.py:79, 119, 146, 173`
+
+**D. Linear `next()`/`index()` scan where a dict already exists → `dict.get`**
+- `dashboard.py:2136` (`item_detail_map`; map already built at 2128)
+- `finalize.py:333,350` (use `item_map`) — *Conf: Medium (duplicate ICodes)*
+- `fast_custom_scoring.py:413,436` (category/pillar code→index maps in `__init__`)
+
+**E. `x in list` membership inside loops → set**
+- `coverage.py:96-97, 158-170, 192-199`
+- `sspi.py:30,33` (item codes as set + `sum(1 for ...)`)
+- `fast_custom_scoring.py:1067` (`ref_set`)
+- `finalize.py:767-768, 788-789` (country groups as sets)
+
+**F. `sum/any/all([listcomp])` → generator** (also restores short-circuit)
+- `dashboard.py:1716-1718` (3 passes → single pass / `sum(1 for ...)`)
+- `coverage.py:107-111`, `sspi.py:194,202,205,206`
+- `utilities.py:353,396` (+ module const `_NUMERIC_TYPES = (int, float)`)
+- > **DO NOT** touch `mongo_wrapper.py:137` `validate_documents_format` `all([...])`: a generator would short-circuit and skip validating later documents — behavior change.
+
+**G. Eliminate repeated identical computation**
+- `dashboard.py:1729,1732` — duplicate `sorted(list(set(...)))` → compute once
+- `fast_custom_scoring.py:161` — `np.isnan(data)` 3× → `nan_mask` once
+- `fast_custom_scoring.py:1182, 824` — re-indexed 3D arrays → hoist per-item 2D views + `nan_mat` (~80k cells/req)
+- `fast_custom_scoring.py:554,558` — strip whitespace once
+- `score_function_validator.py:776,784` — `set.difference(dict)` + only copy `env` when goalpost vars used
+- `utilities.py:299-312` — `drop_none_or_na` O(n²) → single pass
+- `utilities.py:419-428` — hoist `required_keys`, test dict directly
+- `utilities.py:366` — hoist `inspect.getsource()` out of per-document loop
+
+**H. Remove duplicate per-request DB round-trips**
+- `fast_custom_scoring.py:1014` vs `1066` — `country_group()` called twice → fetch once
+- `customize.py:1441-1455` — `get_line_data(config_hash)` full fetch twice → once — *Conf: Medium*
+
+**I. Remove leftover debug `print()` in hot/loop paths** (changes stdout only)
+- `dashboard.py:911` (prints whole `panel_data` per request), `1445, 1447, 1966`
+- `mongo_wrapper.py:310-312` (per-item on bulk insert)
+
+---
+
+## Tier 2 — HOT/WARM, needs a small refactor or Medium confidence
+
+**J. `sspi_metadata` recursion N+1 storms (biggest systemic DB cost)** — `sspi_metadata.py`
+- `:1166` `get_active_schema_dataset_dependencies` — `find_one` per indicator (~50) + O(n²) list membership → one `$in` fetch + dict + `seen` set — *High*
+- `:1114` `get_indicator_dependencies` — `item_codes()` (3 `find_one`) re-queried per node (~230) → thread code-set through recursion — *Medium*
+- `:951,687` `get_dataset_dependencies`/`get_series_type` — up to 4 `find_one` per node → hoist sets into recursion — *Medium*
+- `:711` `get_child_details` — 3 classification `find_one` + re-query → single `get_item_detail`, branch on `ItemType` — *Medium*
+- `:795` `get_country_groups` — scans all `CountryGroup` docs vs precomputed `country_group_map()` — *Medium*
+- `dashboard.py:575-577` — N+1 `find_one` for static ranks in nested loop → preload `rank_map {(ICode,CCode): Rank}` — *High*
+- `dashboard.py:824` — `get_country_groups(cou)` per country → fetch once, build map — *High/Medium*
+- `dashboard.py:2223-2301` — 3 `clean_api_data` queries → one `$in` — *Medium*
+- `query_builder.py:127-141`, `utilities.py:903-908` — likely N+1 metadata; batch if accessor exists — *Medium*
+
+**K.** `fast_custom_scoring._find_parent` — 3 full metadata scans per indicator → precompute parent map in `__init__` — *Medium*
+**L.** `fast_custom_scoring.py:643` — needless `np.array(dataset_stack)` copy on simple-goalpost path — *Medium*
+**M.** `mongo_wrapper.py:90-91` — `sum([...], [])` quadratic flatten → nested comprehension — *High*
+
+---
+
+## Tier 3 — WARM (data-build / ETL / CLI), batchable cleanups
+
+- **WID (`datasource/wid.py:79-84,108`):** `filter_wid_csv` re-parses each country's full data+metadata CSV per `(variable, percentile)` — **dominant WID ETL cost**. Parse each country CSV once, reuse — *Medium, caller-level*. (All 77 `wid/` wrappers are otherwise clean.)
+- `datasource/wid.py:90` — debug log eagerly computes `sorted(unique().tolist())` even when DEBUG off → guard — *High*
+- `datasource/unsdg.py:59` — `any([isinstance,...])` → `isinstance(v, (str, float, int))` — *High*
+- `datasource/unsdg.py:112-131` — `type(v) in [list]` → tuple; drop `.keys()` — *High*
+- `datasource/unfao.py:33` — `any([...])` → generator — *High*
+- `datasource/taxfoundation.py:40` — `.map(lambda x: int(x))` → `.astype(int)` — *High*
+- `datasource/epi.py:46` — row-by-row `re.search` → `str.extract` — *Medium*; `:52-53` drop `.index.tolist()` — *High*
+- `datasource/prisonstudies.py:125,135` — `df.apply(axis=1)` for append → `itertuples` — *Medium*
+- **UNSDG cleaners (13 files):** delete redundant `DatasetCode` re-assignment loop (`filter_sdg` already sets it). **EXCLUDE** `unsdg_intrnt.py`, `unsdg_fampln.py` (loop is load-bearing there) — *High*
+- **Dataset tail:** `unfao_crbnav/frstav` `range(1990,2000)` rebuilt per iter; `sorted(all_years)` per country; sipri `skip_regions`/`skip_countries` → `frozenset`; `unodc_pripop` double full-frame mask; `vdem`/`itu` redundant `str(df.to_json())` — *High; do NOT swap to `to_dict` (NaN handling)*
+- **Compute sus/ms:** `txrdst`/`ginipt` duplicate `get_goalposts()`; `watman.py:165` rescan → `defaultdict`; `senior.py:134` `datetime.now()` in loop; `biodiv`/`stcons` `set([listcomp])`; `airpol`/`recycl` `ref_data`; `fdepth` `any([...])` — *High*
+- `cli/utilities.py:24,36` — hoist regex to module-level `compile` (per-line/per-token on streams) — *High*
+- `cli/commands/collect.py:41-45` — `.get()` once instead of double lookup — *High*
+- `validators.py:26-27` — hoist `_SAFE_RE = re.compile(...)` — *High*
+- `save.py:48` — hoist `list_collection_names()` out of loop — *High*
+- `sspi_raw_api_data.py:146` — hoist `obs.update(kwargs)` out of fragment loop — *High*
+- `connector/SSPIDatabaseConnector.py` — `.env` loaded twice per construction — *High*
+
+---
+
+## Tier 4 — COLD / dead code to delete (free)
+
+- `customize.py:1452` — dead `scored_items` set comp
+- `fast_custom_scoring.py:76` — unused `dataset_to_idx`; `flatten_to_documents` never called
+- `dashboard.py:2086-2094` — dead `multi_index`/`df` build; `1968/1971` duplicate `order_map_literal`
+- `coverage.py:260-262` — dead `child_details` (N `get_item_detail` calls thrown away) — *Medium*
+
+---
+
+## Do-NOT-touch guardrails (flagged by agents)
+
+1. `mongo_wrapper.py:137` `all([...])` — must stay a list (short-circuit would skip validating later docs).
+2. UNSDG/WB `parse_json()` round-trips — load-bearing (convert `insert_many`'s in-place ObjectIds to JSON).
+3. `df.to_json()` → don't swap to `to_dict()` (NaN→null handling differs, changes which rows drop).
+4. `fast_custom_scoring.py:223-240` imputation inner loop — vectorizing relies on a live view of imputed data; a refactor, not logic-preserving.
+
+---
+
+## Bonus — real bugs surfaced (not performance; out of audit scope)
+
+- `coverage.py:292` — references `sspi_clean_api_data` which is **not imported** in the module → latent `NameError` in that branch.
+- `unsdg_socassist.py:28` — early `return parse_json(...)` makes lines 29-33 unreachable → cleaner **never writes** to `sspi_clean_api_data` nor records its range.
+- `who_cstunt.py` / `who_fampln.py` — early `return` → remaining code is dead.
+- Several CLI commands (`coverage`/`metadata`/`extrapolate`/`interpolate`) — `echo_pretty` blocks after `raise` are unreachable dead code.
+- `api/core/load.py` — `json.loads(request.get_json())` double-decode (correctness smell).
+
+---
+
+## Files confirmed clean (no findings)
+
+All 77 `wid/` wrappers; all `wb/` wrappers; most `pg/` & `outcome/` (thin wrappers, several fully commented out); ~18 `sus/`/`ms/` compute files; `iea`/`ilo`/`who`/`fpi`/`epi`/`uis` tails; many models (`rank`, `usermodel`, `utils`, `errors`, `custom_item/panel/user_data`, `clean/indicator/imputed/item` data); datasource `fpi`/`fsi`/`iea`/`ilo`/`imf`/`itu`/`sipri`/`uis`/`vdem`/`wef`/`who`/`worldbank`.

--- a/sspi_flask_app/api/core/customize.py
+++ b/sspi_flask_app/api/core/customize.py
@@ -1437,23 +1437,19 @@ def get_custom_panel_score(item_code):
             if config:
                 custom_metadata = config.get("metadata", [])
 
-        # If no config_id or config not found, try to infer from line data
-        if not custom_metadata:
-            # Get all unique item codes from line data to build scored_item_codes set
-            all_line_data = sspi_custom_panel_data.get_line_data(config_hash)
-            scored_item_codes = {doc["ICode"] for doc in all_line_data}
-
-            # Use default SSPI metadata as base, filtered to scored items
-            custom_metadata = sspi_metadata.item_details(
-                indicator_filter=list(scored_item_codes)
-            )
-
-        # Build tree from custom metadata
-        scored_items = {doc["ICode"] for doc in line_data}
-        # Get all scored items for proper tree building
+        # Line data is needed both to (optionally) infer metadata and to build
+        # the tree below, so fetch it once instead of twice.
         all_line_data = sspi_custom_panel_data.get_line_data(config_hash)
         all_scored_items = {doc["ICode"] for doc in all_line_data}
 
+        # If no config_id or config not found, infer metadata from line data
+        if not custom_metadata:
+            # Use default SSPI metadata as base, filtered to scored items
+            custom_metadata = sspi_metadata.item_details(
+                indicator_filter=list(all_scored_items)
+            )
+
+        # Build tree from custom metadata
         tree = build_custom_tree(custom_metadata, all_scored_items)
 
         if not tree:

--- a/sspi_flask_app/api/core/dashboard.py
+++ b/sspi_flask_app/api/core/dashboard.py
@@ -2126,6 +2126,7 @@ def get_country_rankings(country_code, item_level):
     # Get item metadata to include item names
     item_details = sspi_metadata.item_details()
     item_name_map = {item["ItemCode"]: item["ItemName"] for item in item_details}
+    item_detail_map = {item["ItemCode"]: item for item in item_details}
     # Filter by item level and enrich with item names
     filtered_data = []
     for doc in ranking_data:
@@ -2133,7 +2134,7 @@ def get_country_rankings(country_code, item_level):
         if not item_code:
             continue
         # Get item detail to check item type
-        item_detail = next((item for item in item_details if item["ItemCode"] == item_code), None)
+        item_detail = item_detail_map.get(item_code)
         if not item_detail:
             continue
         item_type = item_detail.get("ItemType", "").lower()

--- a/sspi_flask_app/api/core/dashboard.py
+++ b/sspi_flask_app/api/core/dashboard.py
@@ -2342,12 +2342,12 @@ def get_country_characteristics(country_code):
         year = sspi_rank_data.get("TimePeriod")
 
         # Get total number of countries for this year
-        total_countries_results = sspi_dynamic_rank_data.find({
+        total_countries_count = sspi_dynamic_rank_data.count_documents({
             "ItemCode": "SSPI",
             "TimePeriod": year,
             "TimePeriodType": "Single Year"
         })
-        total_countries = len(list(total_countries_results)) if total_countries_results else None
+        total_countries = total_countries_count if total_countries_count else None
 
         # Format rank with ordinal suffix
         def ordinal(n):

--- a/sspi_flask_app/api/core/dashboard.py
+++ b/sspi_flask_app/api/core/dashboard.py
@@ -153,8 +153,8 @@ def get_dynamic_indicator_line_data(indicator_code):
     if country_query:
         query["CCode"] = {"$in": country_query}
 
-    # Convert cursor to list and check if data exists
-    dynamic_score_data = list(sspi_indicator_dynamic_line_data.find(query))
+    # find() already returns a materialized list
+    dynamic_score_data = sspi_indicator_dynamic_line_data.find(query)
 
     if not dynamic_score_data:
         # No chart data available for this indicator
@@ -437,8 +437,8 @@ def get_dynamic_radar_data(CountryCode):
         },
     ]
 
-    # Execute aggregation pipeline
-    result = list(sspi_dynamic_radar_data.aggregate(pipeline))
+    # Execute aggregation pipeline (already returns a materialized list)
+    result = sspi_dynamic_radar_data.aggregate(pipeline)
 
     if not result:
         return jsonify({"error": f"No radar data found for country {CountryCode}"}), 404
@@ -1056,7 +1056,7 @@ def country_coverage_matrix_data(country_code):
             "Datasets": 1
         }}
     ]
-    imputed_results = list(sspi_imputed_data.aggregate(imputed_pipeline))
+    imputed_results = sspi_imputed_data.aggregate(imputed_pipeline)
 
     # Build lookup for imputed data: (indicator, year) -> {score, datasets}
     imputed_set = {}

--- a/sspi_flask_app/api/core/dashboard.py
+++ b/sspi_flask_app/api/core/dashboard.py
@@ -1713,9 +1713,9 @@ def item_coverage_data(ItemCode, CountryGroup):
     coverage = DataCoverage(2000, 2023, CountryGroup)
     n_squares = (coverage.max_year - coverage.min_year) * len(coverage.country_codes)
     data = coverage.item_coverage_data(ItemCode)
-    complete_coverage = len([d for d in data if d["v"] == d["vComplete"]])
-    one_missing = len([d for d in data if d["v"] == d["vComplete"] - 1])
-    two_or_more_missing = len([d for d in data if d["v"] < d["vComplete"] - 1])
+    complete_coverage = sum(1 for d in data if d["v"] == d["vComplete"])
+    one_missing = sum(1 for d in data if d["v"] == d["vComplete"] - 1)
+    two_or_more_missing = sum(1 for d in data if d["v"] < d["vComplete"] - 1)
     no_observations = n_squares - complete_coverage - one_missing - two_or_more_missing
     return {
         "summary": [

--- a/sspi_flask_app/api/core/dashboard.py
+++ b/sspi_flask_app/api/core/dashboard.py
@@ -1717,6 +1717,7 @@ def item_coverage_data(ItemCode, CountryGroup):
     one_missing = sum(1 for d in data if d["v"] == d["vComplete"] - 1)
     two_or_more_missing = sum(1 for d in data if d["v"] < d["vComplete"] - 1)
     no_observations = n_squares - complete_coverage - one_missing - two_or_more_missing
+    y_codes_sorted = sorted({d["y"] for d in data})
     return {
         "summary": [
             f"Complete Coverage: {complete_coverage} / {n_squares} observations ({complete_coverage / n_squares:.2%})",
@@ -1726,10 +1727,10 @@ def item_coverage_data(ItemCode, CountryGroup):
         ],
         "data": data,
         "title": f"Coverage for {ItemCode}",
-        "labels": sorted(list(set(d["y"] for d in data))),
+        "labels": y_codes_sorted,
         "itemCode": ItemCode,
         "years": list(range(2000, 2024)),
-        "ccodes": sorted(list(set(d["y"] for d in data))),
+        "ccodes": y_codes_sorted,
     }
 
 

--- a/sspi_flask_app/api/core/dashboard.py
+++ b/sspi_flask_app/api/core/dashboard.py
@@ -2227,8 +2227,7 @@ def get_country_characteristics(country_code):
     # Sort by year and get most recent
     population_data = None
     if population_results:
-        population_results_sorted = sorted(population_results, key=lambda x: x.get("Year", 0), reverse=True)
-        population_data = population_results_sorted[0] if population_results_sorted else None
+        population_data = max(population_results, key=lambda x: x.get("Year", 0))
 
     if population_data:
         pop_value = population_data.get("Value")
@@ -2262,8 +2261,7 @@ def get_country_characteristics(country_code):
     # Sort by year and get most recent
     land_area_data = None
     if land_area_results:
-        land_area_results_sorted = sorted(land_area_results, key=lambda x: x.get("Year", 0), reverse=True)
-        land_area_data = land_area_results_sorted[0] if land_area_results_sorted else None
+        land_area_data = max(land_area_results, key=lambda x: x.get("Year", 0))
 
     if land_area_data:
         land_area_value = land_area_data.get("Value")
@@ -2297,8 +2295,7 @@ def get_country_characteristics(country_code):
     # Sort by year and get most recent
     gdp_per_capita_data = None
     if gdp_per_capita_results:
-        gdp_per_capita_results_sorted = sorted(gdp_per_capita_results, key=lambda x: x.get("Year", 0), reverse=True)
-        gdp_per_capita_data = gdp_per_capita_results_sorted[0] if gdp_per_capita_results_sorted else None
+        gdp_per_capita_data = max(gdp_per_capita_results, key=lambda x: x.get("Year", 0))
 
     if gdp_per_capita_data:
         gdp_pc_value = gdp_per_capita_data.get("Value")
@@ -2333,8 +2330,7 @@ def get_country_characteristics(country_code):
     # Sort by TimePeriod (year) and get most recent
     sspi_rank_data = None
     if sspi_rank_results:
-        sspi_rank_results_sorted = sorted(sspi_rank_results, key=lambda x: x.get("TimePeriod", "0"), reverse=True)
-        sspi_rank_data = sspi_rank_results_sorted[0] if sspi_rank_results_sorted else None
+        sspi_rank_data = max(sspi_rank_results, key=lambda x: x.get("TimePeriod", "0"))
 
     if sspi_rank_data:
         rank = sspi_rank_data.get("Rank")

--- a/sspi_flask_app/api/core/dashboard.py
+++ b/sspi_flask_app/api/core/dashboard.py
@@ -908,7 +908,6 @@ def get_series_panel_plot(series_id):
     group_options = sspi_metadata.country_groups()
     yMin = 0
     yMax = 1
-    print("Panel Data:", panel_data)
     for doc in panel_data:
         values = [d for d in doc.get("value", []) if d is not None]
         if values:
@@ -1442,9 +1441,7 @@ def build_indicators_data():
                         dataset = datasets_by_code.get(dataset_code)
                         if dataset:
                             org_code = dataset.get("Source", {}).get("OrganizationCode", "")
-                            print(org_code)
                             org_detail = source_organization_lookup.get(org_code)
-                            print(org_detail)
                             datasets.append(
                                 {
                                     "dataset_code": dataset_code,
@@ -1964,7 +1961,6 @@ def fast_score():
     coverage = DataCoverage(2000, 2023, "SSPI67", countries=country_codes)
     complete_indicators = coverage.complete()
     details_for_scoring = sspi_metadata.item_details(indicator_filter=complete_indicators)
-    print(details_for_scoring)
     indicator_order_map = {d["ItemCode"]: d["ItemOrder"] for d in details_for_scoring if d["ItemType"] == "Indicator"}
     order_map_literal = {"$literal": indicator_order_map}
     min_year = 2000

--- a/sspi_flask_app/api/core/delete.py
+++ b/sspi_flask_app/api/core/delete.py
@@ -194,7 +194,7 @@ def delete_clear_database(database_name):
     timestr = datetime.now().strftime("%s")
     temp_file_path = os.path.join(temp_dir, f"{timestr}_{database_name}.json")
     with open(temp_file_path, 'w') as temp_file:
-        json.dump(list(database.find({})), temp_file)
+        json.dump(database.find({}), temp_file)
     count = database.delete_many({})
     msg = (
         f"Deleted {count} observations from database {database.name}\n"

--- a/sspi_flask_app/api/core/finalize.py
+++ b/sspi_flask_app/api/core/finalize.py
@@ -764,8 +764,8 @@ def finalize_matrix_iterator(local_path, endpoints):
         }
     ]
     result = sspi_indicator_data.aggregate(pipeline)
-    sspi49_countries = sspi_metadata.country_group("SSPI49")
-    sspi_extended_countries = sspi_metadata.country_group("SSPIExtended")
+    sspi49_countries = set(sspi_metadata.country_group("SSPI49"))
+    sspi_extended_countries = set(sspi_metadata.country_group("SSPIExtended"))
     indicator_details, indicator_map = sspi_metadata.indicator_details(), {}
     for detail in indicator_details:
         indicator_map[detail["IndicatorCode"]] = {

--- a/sspi_flask_app/api/core/finalize.py
+++ b/sspi_flask_app/api/core/finalize.py
@@ -347,7 +347,7 @@ def finalize_sspi_dynamic_radar_data():
             pillar_code = pillar_detail['ItemCode']
 
             # Check if this pillar exists in the aggregated data
-            pillar_item = next((item for item in doc["items"] if item["ICode"] == pillar_code), None)
+            pillar_item = item_map.get(pillar_code)
             if not pillar_item:
                 continue  # Skip if pillar not available for this country-year
 

--- a/sspi_flask_app/api/core/sspi/sus/ghg/coalpw.py
+++ b/sspi_flask_app/api/core/sspi/sus/ghg/coalpw.py
@@ -123,7 +123,7 @@ def impute_coalpw():
             all_imputed_datasets.extend(extrapolated_backward + extrapolated_forward + interpolated)
     
     # Combine original datasets with imputations for indicator computation
-    combined_datasets = list(all_coalpw_datasets) + all_imputed_datasets
+    combined_datasets = all_coalpw_datasets + all_imputed_datasets
     
     # Now compute COALPW indicator with complete datasets
     lg, ug = sspi_metadata.get_goalposts("COALPW")

--- a/sspi_flask_app/api/core/sspi/sus/nrg/altnrg.py
+++ b/sspi_flask_app/api/core/sspi/sus/nrg/altnrg.py
@@ -139,7 +139,7 @@ def impute_altnrg():
             all_imputed_datasets.extend(extrapolated_backward + extrapolated_forward + interpolated)
     
     # Combine original datasets with imputations for indicator computation
-    combined_datasets = list(all_altnrg_datasets) + all_imputed_datasets
+    combined_datasets = all_altnrg_datasets + all_imputed_datasets
     
     # Now compute ALTNRG indicator with complete datasets
     lg, ug = sspi_metadata.get_goalposts("ALTNRG")

--- a/sspi_flask_app/api/resources/fast_custom_scoring.py
+++ b/sspi_flask_app/api/resources/fast_custom_scoring.py
@@ -158,16 +158,17 @@ def impute_dataset_vectorized(
     """
     n_countries, n_years = data.shape
     imputed_data = data.copy()
-    imputation_flags = np.isnan(data)
+    nan_mask = np.isnan(data)
+    imputation_flags = nan_mask
 
     # Scenario 1: Entire dataset is empty
-    if np.all(np.isnan(data)):
+    if np.all(nan_mask):
         logger.debug("Entire dataset empty, filling with neutral value")
         imputed_data.fill(neutral_fill)
         return imputed_data, imputation_flags
 
     # Scenario 2: Countries with no data at all - use reference class average
-    has_data_per_country = ~np.all(np.isnan(data), axis=1)  # True if country has any data
+    has_data_per_country = ~np.all(nan_mask, axis=1)  # True if country has any data
     no_data_countries = ~has_data_per_country
 
     if np.any(no_data_countries):
@@ -553,18 +554,19 @@ def _is_simple_goalpost(score_function: str, dataset_codes: list[str]) -> bool:
     if not score_function or len(dataset_codes) != 1:
         return False
 
-    # Normalize whitespace
+    # Normalize whitespace (strip all spaces once for the membership checks)
     normalized = ' '.join(score_function.split())
+    compact = normalized.replace(" ", "")
 
     # Check for simple patterns
     dataset_code = dataset_codes[0]
 
     # Pattern 1: Score = goalpost(DATASET, ...)
-    if f"goalpost({dataset_code}," in normalized.replace(" ", ""):
+    if f"goalpost({dataset_code}," in compact:
         return True
 
     # Pattern 2: Score = goalpost(-DATASET, ...) (inverted)
-    if f"goalpost(-{dataset_code}," in normalized.replace(" ", ""):
+    if f"goalpost(-{dataset_code}," in compact:
         return True
 
     return False
@@ -828,9 +830,10 @@ def compute_ranks_vectorized(all_scores: np.ndarray) -> np.ndarray:
 
     # For each item and year, rank countries by score
     for item_idx in range(n_items):
+        item_scores = all_scores[item_idx]  # 2D view: (n_countries, n_years)
         for year_idx in range(n_years):
             # Get scores for this item and year across all countries
-            year_scores = all_scores[item_idx, :, year_idx]
+            year_scores = item_scores[:, year_idx]
 
             # Handle NaN values - they should get the worst rank
             # argsort returns indices that would sort the array
@@ -1188,14 +1191,21 @@ def _arrays_to_score_dicts(
         # Build list of score documents for this item
         item_docs = []
 
+        # 2D views for this item so the inner loop indexes 2D arrays and the
+        # NaN check reads a precomputed mask instead of re-indexing the 3D
+        # arrays and calling np.isnan per cell.
+        score_mat = all_scores[item_idx]
+        rank_mat = all_ranks[item_idx]
+        nan_mat = np.isnan(score_mat)
+
         for country_idx, country_code in enumerate(country_codes):
             for year_idx in range(n_years):
                 year = start_year + year_idx
-                score = all_scores[item_idx, country_idx, year_idx]
-                rank = all_ranks[item_idx, country_idx, year_idx]
+                score = score_mat[country_idx, year_idx]
+                rank = rank_mat[country_idx, year_idx]
 
                 # Skip NaN scores
-                if np.isnan(score):
+                if nan_mat[country_idx, year_idx]:
                     continue
 
                 item_docs.append({

--- a/sspi_flask_app/api/resources/fast_custom_scoring.py
+++ b/sspi_flask_app/api/resources/fast_custom_scoring.py
@@ -287,6 +287,15 @@ class FastCustomSSPI:
             if item.get("ItemType") == "Pillar"
         ]
 
+        # Code -> index maps for O(1) lookup in the matrix build (codes are
+        # unique per type, so this matches list.index() first-occurrence).
+        self.category_code_to_idx = {
+            code: idx for idx, code in enumerate(self.category_codes)
+        }
+        self.pillar_code_to_idx = {
+            code: idx for idx, code in enumerate(self.pillar_codes)
+        }
+
         # Non-indicator items in order: categories, pillars, SSPI
         self.item_codes = self.category_codes + self.pillar_codes + ["SSPI"]
 
@@ -410,7 +419,7 @@ class FastCustomSSPI:
             category_weight = self._normalized_child_weight(
                 ind_code, category_children
             )
-            category_idx = self.category_codes.index(category_code)
+            category_idx = self.category_code_to_idx[category_code]
             score_matrix[ind_idx, category_idx] = category_weight
 
             pillar = self._find_parent(category_code, "Pillar")
@@ -433,7 +442,7 @@ class FastCustomSSPI:
             pillar_weight = category_weight * self._normalized_child_weight(
                 category_code, pillar_children
             )
-            pillar_idx = self.pillar_codes.index(pillar_code)
+            pillar_idx = self.pillar_code_to_idx[pillar_code]
             score_matrix[ind_idx, n_categories + pillar_idx] = pillar_weight
 
             sspi = self._find_parent(pillar_code, "SSPI")

--- a/sspi_flask_app/api/resources/fast_custom_scoring.py
+++ b/sspi_flask_app/api/resources/fast_custom_scoring.py
@@ -1021,9 +1021,13 @@ def score_custom_configuration_fast(
     Returns:
         Dict mapping item_code -> list of ranked score documents
     """
+    # Reference group countries are used both to default country_codes and to
+    # build the imputation reference mask below - fetch them once.
+    reference_countries = sspi_metadata.country_group(reference_group) or []
+
     # Get country codes if not provided
     if country_codes is None:
-        country_codes = sspi_metadata.country_group(reference_group) or []
+        country_codes = reference_countries
 
     if not country_codes:
         logger.warning(f"No country codes found for reference group {reference_group}")
@@ -1074,9 +1078,10 @@ def score_custom_configuration_fast(
     if progress_callback:
         progress_callback("scoring", 20, "Imputing missing data...")
 
-    # Get reference mask for imputation
-    reference_countries = sspi_metadata.country_group(reference_group) or []
-    reference_mask = np.array([c in reference_countries for c in country_codes])
+    # Get reference mask for imputation (reuse the group fetched above; set
+    # membership is O(1) per country)
+    reference_country_set = set(reference_countries)
+    reference_mask = np.array([c in reference_country_set for c in country_codes])
 
     imputation_flags = {}
     for dataset_code, data_array in dataset_arrays.items():

--- a/sspi_flask_app/api/resources/score_function_validator.py
+++ b/sspi_flask_app/api/resources/score_function_validator.py
@@ -772,21 +772,26 @@ def safe_eval(
         ValueError: If required dataset values are missing
         ScoreFunctionValidationError: If execution fails or the result is non-finite
     """
-    # Check all required dataset codes are present
-    missing = validated_function.dataset_codes - set(dataset_values.keys())
+    # Check all required dataset codes are present (set.difference accepts the
+    # dict directly, avoiding a throwaway set() of its keys each call)
+    missing = validated_function.dataset_codes.difference(dataset_values)
     if missing:
         raise ValueError(f"Missing dataset values: {missing}")
 
     if validated_function.ast is None:
         raise ScoreFunctionValidationError("Score function has no parsed AST to evaluate")
 
-    # Build evaluation environment
-    env = dict(dataset_values)
+    # Build evaluation environment. _eval only reads env, so when no goalpost
+    # variables are injected we can pass dataset_values directly and skip the
+    # per-call copy (the common case in the per-(country, year) hot loop).
     if validated_function.uses_goalposts_as_vars:
+        env = dict(dataset_values)
         if lower_goalpost is not None:
             env["LowerGoalpost"] = lower_goalpost
         if upper_goalpost is not None:
             env["UpperGoalpost"] = upper_goalpost
+    else:
+        env = dataset_values
 
     try:
         score = _eval(validated_function.ast, env)

--- a/sspi_flask_app/api/resources/utilities.py
+++ b/sspi_flask_app/api/resources/utilities.py
@@ -35,6 +35,11 @@ from sspi_flask_app.models.database import (
 from sspi_flask_app.models.errors import InvalidDatabaseError
 
 
+# Accepted numeric types for dataset values (module constant so the tuple is
+# not rebuilt on every membership check inside hot per-document loops).
+_NUMERIC_TYPES = (int, float)
+
+
 # Public databases available for download and querying
 # This is the single source of truth for database configurations
 public_databases = [
@@ -350,7 +355,7 @@ def create_computed_series(
                 dataset["DatasetCode"]: dataset.get("Value", None)
                 for dataset in document["Datasets"]
             }
-            if any((type(v) not in [int, float]) for v in arg_value_dict.values()):
+            if any((type(v) not in _NUMERIC_TYPES) for v in arg_value_dict.values()):
                 continue
             try:
                 arg_value_list = [arg_value_dict[arg] for arg in arg_name_list]
@@ -393,7 +398,7 @@ def score_indicator_documents(
             dataset["DatasetCode"]: dataset.get("Value", None)
             for dataset in document["Datasets"]
         }
-        if any((type(v) not in [int, float]) for v in arg_value_dict.values()):
+        if any((type(v) not in _NUMERIC_TYPES) for v in arg_value_dict.values()):
             continue
         try:
             arg_value_list = [arg_value_dict[arg] for arg in arg_name_list]

--- a/sspi_flask_app/api/resources/utilities.py
+++ b/sspi_flask_app/api/resources/utilities.py
@@ -306,15 +306,13 @@ def drop_none_or_na(intermediate_document_list):
     Utility function for dropping documents with None or NaN values
     """
     noneish_list = []
+    kept_list = []
     for document in intermediate_document_list:
         if document["Value"] is None or math.isnan(document["Value"]):
             noneish_list.append(document)
-    intermediate_document_list = [
-        document
-        for document in intermediate_document_list
-        if document not in noneish_list
-    ]
-    return intermediate_document_list, noneish_list
+        else:
+            kept_list.append(document)
+    return kept_list, noneish_list
 
 
 def group_by_indicator(dataset_document_list, indicator_code) -> list:
@@ -350,6 +348,9 @@ def create_computed_series(
     for vf_spec in value_function_specification:
         series_code, unit, value_function = vf_spec
         arg_name_list = list(inspect.signature(value_function).parameters.keys())
+        # value_function is fixed for this vf_spec, so read its source once
+        # instead of re-parsing the source file for every document.
+        value_function_source = str(inspect.getsource(value_function)).strip()
         for i, document in enumerate(indicator_document_list):
             arg_value_dict = {
                 dataset["DatasetCode"]: dataset.get("Value", None)
@@ -368,7 +369,7 @@ def create_computed_series(
                     "Year": document["Year"],
                     "Value": value_function(*arg_value_list),
                     "Unit": unit,
-                    "ValueFunction": str(inspect.getsource(value_function)).strip(),
+                    "ValueFunction": value_function_source,
                     "Computed": True,
                 } 
                 document["Datasets"].append(new_dataset)
@@ -421,16 +422,15 @@ def filter_incomplete_data(indicator_document_list):
     """
     filtered_list = []
     partial_observation_list = []
+    required_keys = (
+        "IndicatorCode",
+        "CountryCode",
+        "Year",
+        "Unit",
+        "Score",
+    )
     for document in indicator_document_list:
-        key_list = list(document.keys())
-        required_keys = [
-            "IndicatorCode",
-            "CountryCode",
-            "Year",
-            "Unit",
-            "Score",
-        ]
-        if all([key in key_list for key in required_keys]):
+        if all(key in document for key in required_keys):
             filtered_list.append(document)
         else:
             partial_observation_list.append(document)

--- a/sspi_flask_app/client/routes.py
+++ b/sspi_flask_app/client/routes.py
@@ -76,8 +76,7 @@ def get_country_characteristics(country_code):
     })
 
     if sspi_rank_results:
-        sspi_rank_results_sorted = sorted(sspi_rank_results, key=lambda x: x.get("TimePeriod", "0"), reverse=True)
-        sspi_rank_data = sspi_rank_results_sorted[0]
+        sspi_rank_data = max(sspi_rank_results, key=lambda x: x.get("TimePeriod", "0"))
 
         rank = sspi_rank_data.get("Rank")
         score = sspi_rank_data.get("Score")
@@ -116,8 +115,7 @@ def get_country_characteristics(country_code):
     })
 
     if population_results:
-        population_results_sorted = sorted(population_results, key=lambda x: x.get("Year", 0), reverse=True)
-        population_data = population_results_sorted[0]
+        population_data = max(population_results, key=lambda x: x.get("Year", 0))
         pop_value = population_data.get("Value")
 
         characteristics.append({
@@ -143,8 +141,7 @@ def get_country_characteristics(country_code):
     })
 
     if land_area_results:
-        land_area_results_sorted = sorted(land_area_results, key=lambda x: x.get("Year", 0), reverse=True)
-        land_area_data = land_area_results_sorted[0]
+        land_area_data = max(land_area_results, key=lambda x: x.get("Year", 0))
         land_area_value = land_area_data.get("Value")
 
         characteristics.append({
@@ -170,8 +167,7 @@ def get_country_characteristics(country_code):
     })
 
     if gdp_per_capita_results:
-        gdp_per_capita_results_sorted = sorted(gdp_per_capita_results, key=lambda x: x.get("Year", 0), reverse=True)
-        gdp_per_capita_data = gdp_per_capita_results_sorted[0]
+        gdp_per_capita_data = max(gdp_per_capita_results, key=lambda x: x.get("Year", 0))
         gdp_pc_value = gdp_per_capita_data.get("Value")
 
         characteristics.append({

--- a/sspi_flask_app/client/routes.py
+++ b/sspi_flask_app/client/routes.py
@@ -69,11 +69,11 @@ def get_country_characteristics(country_code):
     characteristics = []
 
     # Query SSPI rank and score (most recent year)
-    sspi_rank_results = list(sspi_dynamic_rank_data.find({
+    sspi_rank_results = sspi_dynamic_rank_data.find({
         "CountryCode": country_code,
         "ItemCode": "SSPI",
         "TimePeriodType": "Single Year"
-    }))
+    })
 
     if sspi_rank_results:
         sspi_rank_results_sorted = sorted(sspi_rank_results, key=lambda x: x.get("TimePeriod", "0"), reverse=True)
@@ -110,10 +110,10 @@ def get_country_characteristics(country_code):
         })
 
     # Query population data
-    population_results = list(sspi_clean_api_data.find({
+    population_results = sspi_clean_api_data.find({
         "CountryCode": country_code,
         "DatasetCode": "WB_POPULN"
-    }))
+    })
 
     if population_results:
         population_results_sorted = sorted(population_results, key=lambda x: x.get("Year", 0), reverse=True)
@@ -137,10 +137,10 @@ def get_country_characteristics(country_code):
         })
 
     # Query land area data
-    land_area_results = list(sspi_clean_api_data.find({
+    land_area_results = sspi_clean_api_data.find({
         "CountryCode": country_code,
         "DatasetCode": "WB_LANDAR"
-    }))
+    })
 
     if land_area_results:
         land_area_results_sorted = sorted(land_area_results, key=lambda x: x.get("Year", 0), reverse=True)
@@ -164,10 +164,10 @@ def get_country_characteristics(country_code):
         })
 
     # Query GDP per capita data
-    gdp_per_capita_results = list(sspi_clean_api_data.find({
+    gdp_per_capita_results = sspi_clean_api_data.find({
         "CountryCode": country_code,
         "DatasetCode": "WB_GDP_PERCAP_CURPRICE_USD"
-    }))
+    })
 
     if gdp_per_capita_results:
         gdp_per_capita_results_sorted = sorted(gdp_per_capita_results, key=lambda x: x.get("Year", 0), reverse=True)

--- a/sspi_flask_app/client/routes.py
+++ b/sspi_flask_app/client/routes.py
@@ -84,11 +84,11 @@ def get_country_characteristics(country_code):
         year = sspi_rank_data.get("TimePeriod")
 
         # Get total number of countries for this year
-        total_countries = len(list(sspi_dynamic_rank_data.find({
+        total_countries = sspi_dynamic_rank_data.count_documents({
             "ItemCode": "SSPI",
             "TimePeriod": year,
             "TimePeriodType": "Single Year"
-        })))
+        })
 
         characteristics.append({
             "key": "sspiScore",

--- a/sspi_flask_app/models/coverage.py
+++ b/sspi_flask_app/models/coverage.py
@@ -93,8 +93,9 @@ class DataCoverage:
         :param year_list: The list of years for a given country, given as the
         value of the CountryCode key in the coverage dictionary
         """
+        year_set = set(year_list)
         return all(
-            [year in year_list for year in range(self.min_year, self.max_year + 1)]
+            year in year_set for year in range(self.min_year, self.max_year + 1)
         )
 
     def check_complete_indicator(self, country_year_dict):
@@ -156,14 +157,16 @@ class DataCoverage:
             )
         msg = f"Indicator code {indicator_code} has incomplete coverage:"
         for country in self.country_codes:
-            if not self.check_complete_country(country_year_dict[country]):
-                if len(country_year_dict[country]) == 0:
+            country_years = country_year_dict[country]
+            if not self.check_complete_country(country_years):
+                if len(country_years) == 0:
                     msg += f"\nproblem: {country} has no observations."
                     continue
+                year_set = set(country_years)
                 missing = [
                     y
                     for y in range(self.min_year, self.max_year + 1)
-                    if y not in country_year_dict[country]
+                    if y not in year_set
                 ]
                 if len(missing) == 0:
                     continue
@@ -189,10 +192,11 @@ class DataCoverage:
             if self.check_complete_country(country_year_dict[country_code]):
                 msg += f"\nIndicator code {indicator} has complete coverage from {self.min_year} to {self.max_year}."
             else:
+                year_set = set(country_year_dict[country_code])
                 missing = [
                     y
                     for y in range(self.min_year, self.max_year + 1)
-                    if y not in country_year_dict[country_code]
+                    if y not in year_set
                 ]
                 if len(missing) == 0:
                     continue

--- a/sspi_flask_app/models/coverage.py
+++ b/sspi_flask_app/models/coverage.py
@@ -106,10 +106,8 @@ class DataCoverage:
         coverage dictionary
         """
         return all(
-            [
-                self.check_complete_country(country_year_dict[cou])
-                for cou in self.country_codes
-            ]
+            self.check_complete_country(country_year_dict[cou])
+            for cou in self.country_codes
         )
 
     def complete(self):

--- a/sspi_flask_app/models/database/mongo_wrapper.py
+++ b/sspi_flask_app/models/database/mongo_wrapper.py
@@ -307,9 +307,6 @@ class MongoWrapper:
             self.validate_value(item, document_number)
             self.validate_unit(item, document_number)
             document_id = f"{item['ItemCode']}_{item['CountryCode']}_{item['Year']}"
-            print("==========================")
-            print(document_id)
-            print(item)
             if document_id in id_set:
                 print(f"Document Produced an Error: {item}")
                 raise InvalidDocumentFormatError(

--- a/sspi_flask_app/models/sspi.py
+++ b/sspi_flask_app/models/sspi.py
@@ -27,10 +27,10 @@ class FastSSPI:
         indicator_index = 0
         item_list = ["" for i in range(n_categories + n_pillars)]
         item_list.append("SSPI")
-        item_codes = [d["ItemCode"] for d in self.item_details_sorted]
+        item_codes = {d["ItemCode"] for d in self.item_details_sorted}
         for item in self.item_details_sorted:
             item_type = item['ItemType']
-            multiple = len([c for c in item['Children'] if c in item_codes])
+            multiple = sum(1 for c in item['Children'] if c in item_codes)
             item["TreeIndex"]
             if item_type == "SSPI": ## Fill the last column with the overall SSPI weight
                 sspi_multiple = multiple 

--- a/sspi_flask_app/models/sspi.py
+++ b/sspi_flask_app/models/sspi.py
@@ -191,7 +191,7 @@ class SSPI:
                 raise InvalidDocumentFormatError(
                     f"Category {cat} has no indicators defined."
                 )
-            catsum = sum([self._item_detail_table[ic].score for ic in cat.indicator_codes])
+            catsum = sum(self._item_detail_table[ic].score for ic in cat.indicator_codes)
             catlen = len(cat.indicator_codes)
             cat.score = catsum / catlen
         for pil in self.pillars:
@@ -199,11 +199,11 @@ class SSPI:
                 raise InvalidDocumentFormatError(
                     f"Pillar {pil} has no categories defined."
                 )
-            pilsum = sum([self._item_detail_table[cc].score for cc in pil.category_codes])
+            pilsum = sum(self._item_detail_table[cc].score for cc in pil.category_codes)
             pillen = len(pil.category_codes)
             pil.score = pilsum / pillen
-        self.root.score = sum([self._item_detail_table[p.code].score for p in self.pillars]) / len(self.pillars)
-        assert all([it.score is not None for it in self._item_detail_table.values()]), \
+        self.root.score = sum(self._item_detail_table[p.code].score for p in self.pillars) / len(self.pillars)
+        assert all(it.score is not None for it in self._item_detail_table.values()), \
             "Not all items have a score calculated."
 
     def get_item(self, item_code: str) -> dict:


### PR DESCRIPTION
## Summary

Logic-preserving performance optimizations on the hot request path, plus the
consolidated audit report they came from. **No behavior, output, ordering, or
error semantics change** — only how the same results are computed.

These are Tier 1 of a 14-agent audit of ~30k LOC of production Python
(`docs/python-performance-audit.md`, added in the first commit). Tiers 2–4 and
two real (non-perf) bugs are documented there and left for follow-up.

## What changed (9 atomic commits)

| Pattern | Effect |
|---|---|
| `count_documents` vs `len(list(find()))` | stop fetching + BSON→JSON serializing every rank doc just to count it (per request) |
| drop redundant `list()` | `find()`/`aggregate()` already return lists — removed extra shallow copies |
| `max()` vs `sorted()[0]` | O(n) instead of O(n log n) for "most recent" picks; stable sort ⇒ identical element |
| dict lookups vs `next()`/`.index()` | removed O(n·m) linear scans in ranking, radar, and matrix-build loops |
| sets for membership | `coverage` / `sspi` / `finalize` `x in list` → O(1) |
| generators for `sum/any/all` | drop throwaway intermediate lists; restore short-circuit |
| eliminate repeated computation | `np.isnan` once; hoisted per-item 2D views (~80k cells/req); single-pass `drop_none_or_na`; hoisted `inspect.getsource`; conditional `env` copy in `safe_eval` |
| dedup per-request round-trips | `country_group()` once; `get_line_data()` once |
| remove leftover debug prints | `print(panel_data)` per request; per-item prints on bulk insert |

## Guardrails respected (flagged by the audit)

- `mongo_wrapper.py` `validate_documents_format` `all([...])` left as a **list** — a generator would short-circuit and skip validating later documents.
- UNSDG/WB `parse_json()` round-trips kept (they convert in-place ObjectIds to JSON).
- `df.to_json()` not swapped to `to_dict()` (NaN→null handling differs).

## Testing

- All 13 changed Python files byte-compile.
- `tests/unit`: **968 passed**, 7 pre-existing errors (`DuplicateKeyError` on the
  `unique_score_entry` index from local Mongo state — **confirmed identical on
  `main`**, unrelated to this branch).
- Unit tests directly covering the touched functions
  (`score_function_validator`, `create_computed_series`,
  `filter_incomplete_data`, `coverage`, `sspi_score`) all pass.

## Follow-ups (not in this PR)

- **Tier 2** — `sspi_metadata` recursive-dependency N+1 query storm (biggest
  systemic latency win; needs a small refactor).
- **Tier 3/4** — ETL/CLI cleanups and dead-code deletion.
- **Bugs** — `coverage.py` latent `NameError` (`sspi_clean_api_data` not
  imported in one branch); `unsdg_socassist.py` returns before its write block
  so it never persists to the clean DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
