### PR TITLE
perf: Tier 2 — eliminate metadata N+1 query storms and related hot-path costs

### DIFF
--- a/docs/tier2-metadata-deps-handoff.md
+++ b/docs/tier2-metadata-deps-handoff.md
@@ -2,7 +2,11 @@
 
 **Date:** 2026-06-26
 **Branch:** `perf/tier2-metadata-deps` (created off `main`; this doc is the only commit so far)
-**Status:** Not started — this file is the brief.
+**Status:** Done — implemented in commit `perf(metadata): eliminate N+1 query storm
+in dependency walkers`. The three core walkers are refactored; query counts verified
+to drop (33→12, 20→8, 2→1 on the 5-node test fixture) with byte-identical output, and
+`tests/unit` still reports 968 passed / 7 pre-existing errors. The two optional smaller
+wins (`get_child_details`, `get_country_groups`) were left out of scope.
 **Prereq context:** See `docs/python-performance-audit.md` (the full audit). Tier 1 is already
 done and in draft PR #899 on branch `perf/tier1-hot-path-optimizations` — independent of this work.
 

--- a/docs/tier2-metadata-deps-handoff.md
+++ b/docs/tier2-metadata-deps-handoff.md
@@ -2,11 +2,16 @@
 
 **Date:** 2026-06-26
 **Branch:** `perf/tier2-metadata-deps` (created off `main`; this doc is the only commit so far)
-**Status:** Done — implemented in commit `perf(metadata): eliminate N+1 query storm
-in dependency walkers`. The three core walkers are refactored; query counts verified
-to drop (33→12, 20→8, 2→1 on the 5-node test fixture) with byte-identical output, and
-`tests/unit` still reports 968 passed / 7 pre-existing errors. The two optional smaller
-wins (`get_child_details`, `get_country_groups`) were left out of scope.
+**Status:** Done — the three core walkers are refactored (query counts verified to
+drop 33→12, 20→8, 2→1 on the 5-node test fixture with byte-identical output). The
+branch then grew to cover **all of Tier 2** from the audit: `get_child_details` and
+`get_country_groups` (the two optional smaller wins), the `dashboard.py` N+1 hotspots
+(rank map, country-group map, characteristics `$in`), the `query_builder` source-info
+batch, the `fast_custom_scoring` parent map + deferred stack (K/L), and the
+`mongo_wrapper` quadratic flatten (M). `utilities.py:903` was evaluated and skipped
+(the un-batchable `raw_data_available` is the dominant per-dataset query there, and the
+existing tests assert the `get_source_info` call count). `tests/unit` reports 968 passed
+/ 7 pre-existing errors throughout.
 **Prereq context:** See `docs/python-performance-audit.md` (the full audit). Tier 1 is already
 done and in draft PR #899 on branch `perf/tier1-hot-path-optimizations` — independent of this work.
 

--- a/docs/tier2-metadata-deps-handoff.md
+++ b/docs/tier2-metadata-deps-handoff.md
@@ -1,0 +1,196 @@
+# Handoff: Tier 2 — `sspi_metadata` dependency-walker N+1 fix
+
+**Date:** 2026-06-26
+**Branch:** `perf/tier2-metadata-deps` (created off `main`; this doc is the only commit so far)
+**Status:** Not started — this file is the brief.
+**Prereq context:** See `docs/python-performance-audit.md` (the full audit). Tier 1 is already
+done and in draft PR #899 on branch `perf/tier1-hot-path-optimizations` — independent of this work.
+
+---
+
+## Goal (one sentence)
+
+Eliminate the repeated, identical MongoDB round-trips that the recursive dependency
+walkers in `sspi_flask_app/models/database/sspi_metadata.py` make at every tree node,
+**without changing any public method signature or any returned value.**
+
+---
+
+## The problem
+
+Every metadata accessor is an **uncached** Mongo query. One `find_one` each, every call:
+
+```python
+def pillar_codes(self):     return self.find_one({"DocumentType": "PillarCodes"})["Metadata"]    # 542
+def category_codes(self):   return self.find_one({"DocumentType": "CategoryCodes"})["Metadata"]  # 548
+def indicator_codes(self):  return self.find_one({"DocumentType": "IndicatorCodes"})["Metadata"] # 554
+def dataset_codes(self):    return self.find_one({"DocumentType": "DatasetCodes"})...             # 656
+def item_codes(self):       return ["SSPI"] + indicator_codes() + category_codes() + pillar_codes()  # 569 → 3 queries
+```
+
+`get_series_type` (687) classifies ONE code with up to **4** queries:
+
+```python
+def get_series_type(self, series_code):
+    if series_code in self.dataset_codes():   # 1 query
+        return "Dataset"
+    elif series_code in self.item_codes():    # 3 queries
+        return "Item"
+    return None
+```
+
+`get_dataset_dependencies` (951) calls `get_series_type` (and `get_item_detail`, etc.)
+at **every node, recursively**:
+
+```python
+def get_dataset_dependencies(self, series_code):
+    series_type = self.get_series_type(series_code)         # ~4 queries PER NODE
+    if series_type == "Item":
+        children = self.get_item_detail(series_code)...      # +1 query
+        for c in children:
+            dataset_dependencies += self.get_dataset_dependencies(c)   # recurse
+```
+
+A full SSPI walk (~77 item nodes: 1 root → ~4 pillars → ~16 categories → ~57 indicators)
+re-fetches the SAME global code lists hundreds of times → **~300–500 round-trips** for
+data that is constant for the whole call.
+
+Same shape in `get_indicator_dependencies` (1114): `item_code not in self.item_codes()`
+(3 queries) **+** `get_item_detail` (1 query) at every node.
+
+`get_active_schema_dataset_dependencies` (1145): a `get_indicator_detail` per active
+indicator (~57 sequential queries) **+** an O(n²) `ds_code not in all_datasets` membership
+against a growing **list**.
+
+---
+
+## Targets (exact, with current per-call query cost)
+
+| Fn | Line | Issue | Confidence it's logic-preserving |
+|---|---|---|---|
+| `get_active_schema_dataset_dependencies` | 1166 | `get_indicator_detail` per indicator (N+1) **+** O(n²) `not in all_datasets` list | High |
+| `get_indicator_dependencies` | 1114 | `item_codes()` (3 q) + `get_item_detail` (1 q) per recursion node | Medium (needs helper) |
+| `get_dataset_dependencies` → `get_series_type` | 951 / 687 | up to 4 `find_one` per node | Medium (needs helper) |
+| `get_child_details` | 711 | 3 classification `find_one` + re-query before the real query | Medium |
+| `get_country_groups` | 795 | scans all `CountryGroup` docs vs precomputed `country_group_map()` | Medium |
+
+---
+
+## The fix pattern
+
+The metadata is **immutable for the duration of one top-level call.** So fetch the code
+sets / detail maps ONCE and thread them through an internal recursive helper. Keep the
+public method as a thin wrapper so its signature and behavior are unchanged.
+
+```python
+def get_dataset_dependencies(self, series_code: str) -> list:
+    # public signature unchanged — fetch invariants once, then recurse query-free
+    dataset_set = set(self.dataset_codes())
+    item_set = set(self.item_codes())
+    return self._get_dataset_dependencies(series_code, dataset_set, item_set)
+
+def _get_dataset_dependencies(self, series_code, dataset_set, item_set):
+    if series_code in dataset_set:
+        return [series_code]
+    if series_code in item_set:
+        children = self.get_item_detail(series_code).get("Children", [])
+        if not children and series_code in item_set:  # was: in self.indicator_codes()
+            children = self.get_indicator_detail(series_code).get("DatasetCodes", [])
+        assert not any(c is None for c in children)
+        deps = []
+        for c in children:
+            deps += self._get_dataset_dependencies(c, dataset_set, item_set)
+        return deps
+    return []
+```
+
+Apply the same shape to `get_indicator_dependencies` (thread `item_set` + an
+`item_detail_map`). For `get_active_schema_dataset_dependencies`: replace the per-indicator
+`get_indicator_detail` loop with ONE `self.find({"DocumentType": "IndicatorDetail",
+"Metadata.IndicatorCode": {"$in": active_indicator_codes}})` → build a
+`{code: Metadata}` dict, iterate `active_indicator_codes` in order reading from the dict;
+and make `all_datasets` membership use a parallel `set` while keeping the **list** for the
+ordered output. For `get_child_details` (711) and `get_country_groups` (795), see the
+audit report's Tier 2 section — both are independent, smaller wins; do them only if cheap.
+
+> ⚠️ Subtle equivalence point: in the original, `series_code in self.indicator_codes()`
+> tests membership against the indicator-codes list specifically, NOT all item codes.
+> If you collapse it to `item_set`, confirm that branch only matters when `Children` is
+> empty AND the code is an indicator — verify against `test_get_dataset_dependencies.py`
+> before assuming `item_set` is a safe substitute. If unsure, thread a separate
+> `indicator_set`.
+
+---
+
+## Why it's logic-preserving
+
+Within a single call, the metadata documents do not change, so reading `dataset_codes()` /
+`item_codes()` once and reusing the result yields the **same** classification and the
+**same** recursion as re-reading them per node. The `in list` → `in set` swap preserves
+membership semantics over unique codes. Outputs (and their order, for the dependency lists)
+are identical.
+
+## Why it was NOT in Tier 1
+
+The public signature `get_dataset_dependencies(series_code)` has no place to carry the
+precomputed sets, so you must add a private recursive helper (or a request-scoped cache).
+That's a small **refactor**, which is the exact line Tier 1 (pure local line-edits) did not
+cross. It's still safe — it just needs the helper.
+
+---
+
+## Public API must stay stable — external callers
+
+Do **not** change these signatures; they're called from:
+
+- `get_dataset_dependencies`: `api/resources/query_builder.py:128`, `api/core/delete.py:148,157`,
+  `api/core/dataset.py:64,122` (+ unit test below)
+- `get_indicator_dependencies`: `api/core/delete.py:158`, `api/core/sspi/__init__.py:119,146`
+- `get_active_schema_dataset_dependencies`: `api/core/dashboard.py:1005`
+- `get_series_type`: `api/core/query.py:123`
+- `get_child_details`: `api/core/dashboard.py:1335`
+
+---
+
+## Definition of done
+
+1. `get_dataset_dependencies`, `get_indicator_dependencies`,
+   `get_active_schema_dataset_dependencies` return **byte-identical** results to `main` for
+   the same inputs (lists in the same order).
+2. Public signatures unchanged; all callers above untouched.
+3. Per-call Mongo round-trips drop from O(nodes) to a small constant (rough check: count
+   `find`/`find_one` calls, e.g. monkeypatch or log, for `get_dataset_dependencies("SSPI")`).
+4. `pytest tests/unit/models/test_get_dataset_dependencies.py` passes (this is the safety
+   net — it asserts exact dependency lists for UNSDG_*, BIODIV, REDLST, ECO, SUS, SSPI).
+5. Whole `tests/unit` suite: same pass count as `main`. NOTE: `main` currently has **7
+   pre-existing errors** in `tests/unit/security/test_*_bp.py` — a local-Mongo
+   `DuplicateKeyError` on the `unique_score_entry` index, NOT related to this work. Confirm
+   your count matches `main`'s (968 passed, 7 errors at time of writing).
+6. Atomic commits, conventional messages (`perf:` / `refactor:`).
+
+## How to verify
+
+```bash
+python -m py_compile sspi_flask_app/models/database/sspi_metadata.py
+pytest tests/unit/models/test_get_dataset_dependencies.py -q     # primary safety net
+pytest tests/unit -q                                             # full unit sweep
+```
+
+To prove the query reduction, temporarily wrap `find`/`find_one` with a counter (or use
+`caplog`) around `get_dataset_dependencies("SSPI")` before vs after.
+
+## Guardrails (do NOT touch — from the audit)
+
+- `mongo_wrapper.py:137` `validate_documents_format` `all([...])` must stay a **list**
+  (generator would short-circuit and skip validating later docs).
+- Don't add a process-wide metadata cache without an invalidation story — scope any cache
+  to the single call (helper-threading is simplest and safest).
+- Keep `get_series_type`'s `None` return for unknown codes, and `get_item_detail`'s
+  `{"Error": ...}` / empty-children fallbacks.
+
+## Out of scope
+
+`get_country_groups` (795) and `get_child_details` (711) are listed as optional smaller
+wins; the core deliverable is the three dependency walkers. The Tier 1 PR (#899) and the
+two non-perf bugs (`coverage.py:292` latent `NameError`; `unsdg_socassist.py` early return)
+are tracked separately in `docs/python-performance-audit.md`.

--- a/sspi_flask_app/api/core/dashboard.py
+++ b/sspi_flask_app/api/core/dashboard.py
@@ -553,6 +553,12 @@ def get_static_pillar_stack(pillar_code):
     labels = []
     code_map = {}
     pillar_name = ""
+    # Preload every (indicator, country) rank once instead of one find_one per
+    # indicator per country inside the nested loop below. First match wins, to
+    # mirror the previous find_one's natural-order selection.
+    rank_map = {}
+    for r in sspi_static_rank_data.find({}, {"_id": 0}):
+        rank_map.setdefault((r["ICode"], r["CCode"]), r["Rank"])
     for i, cou in enumerate(country_codes):
         cou_data = sspi_static_data_2018.find({"CountryCode": cou}, {"_id": 0})
         cou_sspi = SSPI(item_details, cou_data, strict_year=False)
@@ -572,9 +578,7 @@ def get_static_pillar_stack(pillar_code):
             for ind_code in category.indicator_codes:
                 indicator = cou_sspi.get_item(ind_code)
                 dataset = {}
-                indicator_rank = sspi_static_rank_data.find_one(
-                    {"ICode": indicator.code, "CCode": cou}, {"_id": 0}
-                )["Rank"]
+                indicator_rank = rank_map[(indicator.code, cou)]
                 data = [None] * len(pillar.category_codes)
                 n_indicators = len(category.indicator_codes)
                 dataset["CatCode"] = category.code
@@ -808,6 +812,9 @@ def prepare_panel_data():
             return jsonify({"error": "Too many series levels to display"})
         yield "================\n"
         count = 1
+        # Country->groups is invariant across every series and country here, so
+        # fetch the precomputed map once instead of scanning per country.
+        country_group_map = sspi_metadata.country_group_map()
         for series in series_group_list:
             min_year = 2000
             max_year = datetime.now().year
@@ -821,7 +828,7 @@ def prepare_panel_data():
             yield "================\n"
             for cou, document in series["Datasets"].items():
                 document = sorted(document, key=lambda x: x["time_id"])
-                group_list = sspi_metadata.get_country_groups(cou)
+                group_list = country_group_map.get(cou, [])
                 year = [None] * len(label_list)
                 value = [None] * len(label_list)
                 data = [None] * len(label_list)
@@ -2219,11 +2226,21 @@ def get_country_characteristics(country_code):
             else:
                 return f"{value:,.0f}"
 
-    # Query population data (most recent year)
-    population_results = sspi_clean_api_data.find({
+    # Fetch population, land area, and GDP-per-capita in a single round-trip,
+    # then bucket by DatasetCode. Each block below keeps its original
+    # most-recent-year selection logic unchanged.
+    characteristic_datasets = ["WB_POPULN", "WB_LANDAR", "WB_GDP_PERCAP_CURPRICE_USD"]
+    characteristic_results = {ds: [] for ds in characteristic_datasets}
+    for characteristic_doc in sspi_clean_api_data.find({
         "CountryCode": country_code,
-        "DatasetCode": "WB_POPULN"
-    })
+        "DatasetCode": {"$in": characteristic_datasets}
+    }):
+        bucket = characteristic_results.get(characteristic_doc.get("DatasetCode"))
+        if bucket is not None:
+            bucket.append(characteristic_doc)
+
+    # Population data (most recent year)
+    population_results = characteristic_results["WB_POPULN"]
     # Sort by year and get most recent
     population_data = None
     if population_results:
@@ -2254,11 +2271,8 @@ def get_country_characteristics(country_code):
             "available": False
         })
 
-    # Query land area data (most recent year)
-    land_area_results = sspi_clean_api_data.find({
-        "CountryCode": country_code,
-        "DatasetCode": "WB_LANDAR"
-    })
+    # Land area data (most recent year)
+    land_area_results = characteristic_results["WB_LANDAR"]
     # Sort by year and get most recent
     land_area_data = None
     if land_area_results:
@@ -2289,11 +2303,8 @@ def get_country_characteristics(country_code):
             "available": False
         })
 
-    # Query GDP per capita data (most recent year)
-    gdp_per_capita_results = sspi_clean_api_data.find({
-        "CountryCode": country_code,
-        "DatasetCode": "WB_GDP_PERCAP_CURPRICE_USD"
-    })
+    # GDP per capita data (most recent year)
+    gdp_per_capita_results = characteristic_results["WB_GDP_PERCAP_CURPRICE_USD"]
     # Sort by year and get most recent
     gdp_per_capita_data = None
     if gdp_per_capita_results:

--- a/sspi_flask_app/api/resources/fast_custom_scoring.py
+++ b/sspi_flask_app/api/resources/fast_custom_scoring.py
@@ -290,6 +290,10 @@ class FastCustomSSPI:
         # Non-indicator items in order: categories, pillars, SSPI
         self.item_codes = self.category_codes + self.pillar_codes + ["SSPI"]
 
+        # Map (child_code, parent_type) -> parent item for O(1) parent lookups,
+        # replacing a full metadata scan per indicator in _build_score_matrix.
+        self._parent_map = self._build_parent_map()
+
         # Build the aggregation matrix
         self.score_matrix = self._build_score_matrix()
 
@@ -461,6 +465,28 @@ class FastCustomSSPI:
         logger.debug(f"Score matrix built with shape {score_matrix.shape}")
         return score_matrix
 
+    def _build_parent_map(self) -> dict:
+        """
+        Precompute a ``{(child_code, parent_type): parent_item}`` lookup using
+        the same child-resolution and first-match-wins ordering that the
+        per-call ``_find_parent`` scan relied on.
+        """
+        parent_map = {}
+        for item in self.metadata:
+            item_type = item.get("ItemType")
+            children = (
+                item.get("IndicatorCodes") or
+                item.get("CategoryCodes") or
+                item.get("PillarCodes") or
+                item.get("Children") or
+                []
+            )
+            for child_code in children:
+                key = (child_code, item_type)
+                if key not in parent_map:
+                    parent_map[key] = item
+        return parent_map
+
     def _find_parent(self, child_code: str, parent_type: str) -> dict | None:
         """
         Find the parent item of a given type for a child code.
@@ -472,19 +498,7 @@ class FastCustomSSPI:
         Returns:
             Parent item dict or None if not found
         """
-        for item in self.metadata:
-            if item.get("ItemType") != parent_type:
-                continue
-            children = (
-                item.get("IndicatorCodes") or
-                item.get("CategoryCodes") or
-                item.get("PillarCodes") or
-                item.get("Children") or
-                []
-            )
-            if child_code in children:
-                return item
-        return None
+        return self._parent_map.get((child_code, parent_type))
 
     def aggregate(self, indicator_scores: np.ndarray) -> np.ndarray:
         """
@@ -639,15 +653,13 @@ def score_indicators_vectorized(
                 f"Scores will be NaN where data is missing."
             )
 
-        # Convert to array of shape (n_datasets, n_countries, n_years)
-        dataset_stack = np.array(dataset_stack)
-
         # Check if this is a simple goalpost function
         is_simple_goalpost = _is_simple_goalpost(score_function_str, dataset_codes)
 
         if is_simple_goalpost and lower_goalpost is not None and upper_goalpost is not None:
-            # Fast path: vectorized goalpost scoring
-            # For simple goalpost, there should be exactly one dataset
+            # Fast path: vectorized goalpost scoring. Only the first dataset is
+            # needed, so index the list directly instead of materializing the
+            # full (n_datasets, n_countries, n_years) stack.
             values = dataset_stack[0]  # shape: (n_countries, n_years)
 
             # Check if inverted (e.g., "Score = goalpost(-DATASET, -100, 0)")
@@ -659,7 +671,9 @@ def score_indicators_vectorized(
 
             logger.debug(f"Scored {indicator_code} using vectorized goalpost")
         else:
-            # Slow path: custom score function evaluation
+            # Slow path: custom score function evaluation. Materialize the 3D
+            # stack only here, where the full array is consumed.
+            dataset_stack = np.array(dataset_stack)
             try:
                 indicator_scores[i] = _apply_custom_score_function(
                     score_function_str,

--- a/sspi_flask_app/api/resources/query_builder.py
+++ b/sspi_flask_app/api/resources/query_builder.py
@@ -130,9 +130,19 @@ def build_mongo_query(raw_query_input, database=None):
 
         # Special handling for raw data queries - use Source fields
         if database is sspi_raw_api_data:
+            # Batch the dataset-detail lookups into one fetch instead of a
+            # find_one per dataset code via get_source_info.
+            dataset_detail_map = {
+                d["DatasetCode"]: d for d in sspi_metadata.dataset_details()
+            }
             source_queries = []
             for dataset_code in dataset_codes:
-                source_info = sspi_metadata.get_source_info(dataset_code)
+                detail = dataset_detail_map.get(dataset_code)
+                if not detail:
+                    raise ValueError(
+                        f"Dataset code {dataset_code} not found in metadata."
+                    )
+                source_info = detail["Source"]
                 source_queries.append(
                     {
                         "Source.OrganizationCode": source_info["OrganizationCode"],

--- a/sspi_flask_app/models/database/mongo_wrapper.py
+++ b/sspi_flask_app/models/database/mongo_wrapper.py
@@ -87,8 +87,11 @@ class MongoWrapper:
         and returns a count of deleted documents
         """
         tab_ids = self.tabulate_ids()
-        id_delete_list = [ObjectId(str(oid["$oid"])) for oid in sum(
-            [obs["ids"][1:] for obs in tab_ids], [])]
+        id_delete_list = [
+            ObjectId(str(oid["$oid"]))
+            for obs in tab_ids
+            for oid in obs["ids"][1:]
+        ]
         query = {"_id": {"$in": id_delete_list}}
         return self._mongo_database.delete_many(query).deleted_count
 

--- a/sspi_flask_app/models/database/sspi_metadata.py
+++ b/sspi_flask_app/models/database/sspi_metadata.py
@@ -952,18 +952,42 @@ class SSPIMetadata(MongoWrapper):
         """
         Returns the list of datasets on which the provided series_code depends
         """
-        series_type = self.get_series_type(series_code)
-        if series_type == "Dataset":
+        # The code lists are constant for the duration of one walk, so fetch them
+        # once here and thread them through the recursion instead of re-querying
+        # Mongo at every node (see the Tier 2 metadata perf brief).
+        dataset_set = set(self.dataset_codes())
+        item_set = set(self.item_codes())
+        indicator_set = set(self.indicator_codes())
+        return self._get_dataset_dependencies(
+            series_code, dataset_set, item_set, indicator_set
+        )
+
+    def _get_dataset_dependencies(
+        self,
+        series_code: str,
+        dataset_set: set,
+        item_set: set,
+        indicator_set: set,
+    ) -> list:
+        """
+        Recursive worker for get_dataset_dependencies. The classification sets are
+        supplied by the public wrapper so this walk issues no repeated global
+        metadata queries. Classification order (Dataset before Item) and the
+        indicator-codes-specific fallback are preserved exactly.
+        """
+        if series_code in dataset_set:
             return [ series_code ]
-        elif series_type == "Item":
+        elif series_code in item_set:
             children = self.get_item_detail(series_code).get("Children", [])
-            if not children and series_code in self.indicator_codes():
+            if not children and series_code in indicator_set:
                 children = self.get_indicator_detail(series_code).get("DatasetCodes", [])
             assert not any([c is None for c in children])
             dataset_dependencies = []
             for c in children:
-                dataset_dependencies = dataset_dependencies + self.get_dataset_dependencies(c)
-            return dataset_dependencies   
+                dataset_dependencies = dataset_dependencies + self._get_dataset_dependencies(
+                    c, dataset_set, item_set, indicator_set
+                )
+            return dataset_dependencies
         else:
             return []
 
@@ -1115,7 +1139,17 @@ class SSPIMetadata(MongoWrapper):
         """
         Returns the list indicator codes on which the provided series_code depends
         """
-        if item_code not in self.item_codes():
+        # item_codes() is constant across the walk; fetch it once and thread it
+        # through the recursion rather than re-querying it at every node.
+        item_set = set(self.item_codes())
+        return self._get_indicator_dependencies(item_code, item_set)
+
+    def _get_indicator_dependencies(self, item_code: str, item_set: set) -> list:
+        """
+        Recursive worker for get_indicator_dependencies. item_set is supplied by the
+        public wrapper so the per-node membership check issues no extra queries.
+        """
+        if item_code not in item_set:
             return []
         item_detail = self.get_item_detail(item_code)
         if not item_detail:
@@ -1127,8 +1161,8 @@ class SSPIMetadata(MongoWrapper):
             assert not any([c is None for c in children])
             item_dependencies = []
             for c in children:
-                item_dependencies += self.get_indicator_dependencies(c)
-            return item_dependencies   
+                item_dependencies += self._get_indicator_dependencies(c, item_set)
+            return item_dependencies
     
     def time_period_details(self) -> list[dict]:
         details = self.find({"DocumentType": "TimePeriodDetail"})
@@ -1159,12 +1193,25 @@ class SSPIMetadata(MongoWrapper):
             "allDatasets": ["UNSDG_TERRST", ...]  # Ordered list
         }
         """
+        # Fetch every active indicator's detail in a single query and index it by
+        # IndicatorCode, instead of issuing one find_one per indicator.
+        detail_map = {}
+        for doc in self.find({
+            "DocumentType": "IndicatorDetail",
+            "Metadata.IndicatorCode": {"$in": active_indicator_codes}
+        }):
+            meta = doc.get("Metadata", {})
+            detail_map[meta.get("IndicatorCode")] = meta
+
         indicator_to_datasets = {}
         dataset_to_indicator = {}
         all_datasets = []
+        # Parallel set mirrors all_datasets so membership is O(1); the list still
+        # carries the ordered, deduplicated output.
+        all_datasets_seen = set()
 
         for indicator_code in active_indicator_codes:
-            detail = self.get_indicator_detail(indicator_code)
+            detail = detail_map.get(indicator_code)
             if not detail:
                 continue
             dataset_codes = detail.get("DatasetCodes", [])
@@ -1176,7 +1223,8 @@ class SSPIMetadata(MongoWrapper):
             indicator_to_datasets[indicator_code] = dataset_codes
             for ds_code in dataset_codes:
                 dataset_to_indicator[ds_code] = indicator_code
-                if ds_code not in all_datasets:
+                if ds_code not in all_datasets_seen:
+                    all_datasets_seen.add(ds_code)
                     all_datasets.append(ds_code)
 
         return {

--- a/sspi_flask_app/models/database/sspi_metadata.py
+++ b/sspi_flask_app/models/database/sspi_metadata.py
@@ -716,14 +716,18 @@ class SSPIMetadata(MongoWrapper):
         """
         if ItemCode == "SSPI":
             return self.find({"DocumentType": "PillarDetail"})
-        elif ItemCode in self.pillar_codes():
-            category_codes = self.get_pillar_detail(ItemCode)["Children"]
+        # One detail lookup classifies the item and supplies its children,
+        # replacing the previous chain of pillar/category/indicator code-list
+        # queries followed by a second detail re-query.
+        detail = self.get_item_detail(ItemCode)
+        item_type = detail.get("ItemType")
+        if item_type == "Pillar":
+            category_codes = detail["Children"]
             return self.find({"DocumentType": "CategoryDetail", "Metadata.ItemCode": {"$in": category_codes}})
-        elif ItemCode in self.category_codes():
-            indicator_codes = self.get_category_detail(ItemCode)["Children"]
+        elif item_type == "Category":
+            indicator_codes = detail["Children"]
             return self.find({"DocumentType": "IndicatorDetail", "Metadata.ItemCode": {"$in": indicator_codes}})
-        elif ItemCode in self.indicator_codes():
-            detail = self.get_indicator_detail(ItemCode)  # Ensure the indicator exists
+        elif item_type == "Indicator":
             child_codes = detail.get("DatasetCodes", [])
             return self.find({"DocumentType": "DatasetDetail", "Metadata.DatasetCode": {"$in": child_codes}})
         else:
@@ -796,12 +800,10 @@ class SSPIMetadata(MongoWrapper):
         """
         Return a list containing the group names to which the country belongs
         """
-        groups = self.find({"DocumentType": "CountryGroup"})
-        group_list = []
-        for g in groups:
-            if country_code in g["Metadata"]["Countries"]:
-                group_list.append(g["Metadata"]["CountryGroupName"])
-        return group_list
+        # The precomputed CountryGroupMap is built by iterating the same
+        # CountryGroup documents in the same order this method used to scan, so
+        # the per-country group list is identical without the full collection scan.
+        return self.country_group_map().get(country_code, [])
 
     def indicator_details(self, filter=[]) -> list[dict]:
         """


### PR DESCRIPTION
## Summary

Tier 2 of the logic-preserving performance audit (`docs/python-performance-audit.md`). Tier 1 is the independent draft #899. Every change here preserves public signatures, returned values, ordering, and error semantics — the wins come from removing repeated/identical DB round-trips and quadratic work.

## Changes

### Metadata dependency walkers (the systemic N+1 storm)
The recursive walkers re-fetched the same immutable global code lists at **every tree node**. Now the invariant sets are fetched once in a thin public wrapper and threaded through a private recursive helper.
- `get_dataset_dependencies` / `get_indicator_dependencies` — thread the classification sets; preserve Dataset-before-Item order and the indicator-codes-specific `DatasetCodes` fallback.
- `get_active_schema_dataset_dependencies` — one batched `find({$in})` indexed by code instead of a `get_indicator_detail` per indicator; ordered `allDatasets` backed by a parallel set (O(n²) → O(1)).

### Other Tier 2 items
- `get_child_details` — one `get_item_detail` + branch on `ItemType`, replacing up to 4 classification/re-query `find_one`s.
- `get_country_groups` — `country_group_map().get(code, [])` instead of scanning every `CountryGroup` doc (the map is built from the same docs in the same order).
- `dashboard.py` — preload a `{(ICode, CCode): Rank}` map (was find_one per indicator per country); fetch population/land-area/GDP in one `$in` query; hoist `country_group_map()` once in the panel stream.
- `query_builder.py` — batch dataset-detail lookups for raw-data source-query construction.
- `fast_custom_scoring.py` — precompute a `(child, parent_type) → parent` map (was 3 full metadata scans per indicator); materialize the 3D dataset stack only on the custom-function slow path.
- `mongo_wrapper.py` — O(n²) `sum([...], [])` flatten → single-pass comprehension.

`utilities.py:903` was evaluated and **skipped**: the un-batchable `raw_data_available` is the dominant per-dataset query there, and the existing tests assert the `get_source_info` call count, so batching would break the contract for only a partial win.

## Verification

- **Byte-identical output** confirmed via `git stash` A/B harnesses for the walkers (`get_dataset_dependencies('SSPI')` etc.) and the `fast_custom_scoring` score matrix.
- **Query counts** (5-node fixture): walkers 33→12, 20→8, 2→1; the saving compounds on the full ~77-node tree where the eliminated queries were the per-node global re-fetches.
- `pytest tests/unit` — **968 passed, 7 errors** throughout, identical to `main` (the 7 are pre-existing `DuplicateKeyError`s in `tests/unit/security/test_*_bp.py`, unrelated).
- The custom-scoring integration test errors identically (11) on `main` and this branch — a pre-existing `unique_score_entry` DB-state issue, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)