### PR TITLE
perf: Tier 3 ETL/CLI cleanups (logic-preserving)

### DIFF
--- a/cli/commands/collect.py
+++ b/cli/commands/collect.py
@@ -38,11 +38,12 @@ def collect(series_code, overwrite_all: bool, overwrite: list[str], remote: bool
         if collected_datasets:
             for dataset in collected_datasets:
                 click.echo(f"A RawDocumentSet for {dataset} has already been collected.")
-                if dataset in previous_collection_info.keys():
+                if dataset in previous_collection_info:
+                    previous_info = previous_collection_info[dataset]
                     click.echo("Previous collection info:")
-                    click.secho(json.dumps(previous_collection_info[dataset]["CollectionInfo"], indent=2), fg="yellow")
+                    click.secho(json.dumps(previous_info["CollectionInfo"], indent=2), fg="yellow")
                     click.echo("Source Info:")
-                    click.secho(json.dumps(previous_collection_info[dataset]["Source"], indent=2), fg="yellow")
+                    click.secho(json.dumps(previous_info["Source"], indent=2), fg="yellow")
                 if click.confirm("Do you want to overwrite the RawDocumentSet associated with this dataset?"):
                     overwrite_list.append(dataset)
         if overwrite_list:

--- a/cli/utilities.py
+++ b/cli/utilities.py
@@ -6,6 +6,10 @@ import click
 import sys
 
 
+_NUMERIC_RE = re.compile(r"^[0-9,.]+$")
+_TOKEN_SPLIT_RE = re.compile(r"([\[\],()\s]+)")
+
+
 def full_name(name):
     if name == "raw":
         return "sspi_raw_api_data"
@@ -21,8 +25,7 @@ def full_name(name):
 
 
 def is_numeric_string(string):
-    pattern = r"^[0-9,.]+$"
-    return bool(re.match(pattern, string))
+    return bool(_NUMERIC_RE.match(string))
 
 
 def echo_pretty(msg):
@@ -33,7 +36,7 @@ def echo_pretty(msg):
         if "error:" in line[0:8] or "problem:" in line[0:9]:
             click.secho(line.split(": ", 1)[1], fg="red")
             continue
-        tokens = re.split(r"([\[\],()\s]+)", line)
+        tokens = _TOKEN_SPLIT_RE.split(line)
         output = []
         for i, t in enumerate(tokens):
             if is_numeric_string(t):

--- a/connector/SSPIDatabaseConnector.py
+++ b/connector/SSPIDatabaseConnector.py
@@ -13,6 +13,8 @@ log = logging.getLogger(__name__)
 
 class SSPIDatabaseConnector:
     def __init__(self):
+        basedir = path.abspath(path.dirname(path.dirname(__file__)))
+        load_dotenv(path.join(basedir, '.env'))
         self.remote_token = self.get_token()
         self.local_token = self.get_token(token_name="SSPI_APIKEY_LOCAL")
         ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
@@ -38,8 +40,6 @@ class SSPIDatabaseConnector:
         self.remote_base = "https://sspi.world"
 
     def get_token(self, token_name="SSPI_APIKEY"):
-        basedir = path.abspath(path.dirname(path.dirname(__file__)))
-        load_dotenv(path.join(basedir, '.env'))
         key = environ.get(token_name)
         if key is None:
             log.error("No API key found in environment variables")

--- a/sspi_flask_app/api/core/datasets/unsdg/unsdg_benfts_cash_poor.py
+++ b/sspi_flask_app/api/core/datasets/unsdg/unsdg_benfts_cash_poor.py
@@ -25,8 +25,6 @@ def clean_unsdg_benfts_cash_poor():
     cleaned_data = filter_sdg(
         extracted_data, {"SI_COV_POOR": "UNSDG_BENFTS_CASH_POOR"}, sex="BOTHSEX",
     )
-    for obs in cleaned_data:
-        obs["DatasetCode"] = "UNSDG_BENFTS_CASH_POOR"
     sspi_clean_api_data.insert_many(cleaned_data)
     sspi_metadata.record_dataset_range(cleaned_data, "UNSDG_BENFTS_CASH_POOR")
     return parse_json(cleaned_data)

--- a/sspi_flask_app/api/core/datasets/unsdg/unsdg_benfts_cash_vuln.py
+++ b/sspi_flask_app/api/core/datasets/unsdg/unsdg_benfts_cash_vuln.py
@@ -25,8 +25,6 @@ def clean_unsdg_benfts_cash_vuln():
     cleaned_data = filter_sdg(
         extracted_data, {"SI_COV_VULN": "UNSDG_BENFTS_CASH_VULN"}, sex="BOTHSEX",
     )
-    for obs in cleaned_data:
-        obs["DatasetCode"] = "UNSDG_BENFTS_CASH_VULN"
     sspi_clean_api_data.insert_many(cleaned_data)
     sspi_metadata.record_dataset_range(cleaned_data, "UNSDG_BENFTS_CASH_VULN")
     return parse_json(cleaned_data)

--- a/sspi_flask_app/api/core/datasets/unsdg/unsdg_benfts_child.py
+++ b/sspi_flask_app/api/core/datasets/unsdg/unsdg_benfts_child.py
@@ -25,8 +25,6 @@ def clean_unsdg_benfts_child():
     cleaned_data = filter_sdg(
         extracted_data, {"SI_COV_CHLD": "UNSDG_BENFTS_CHILD"}, sex="BOTHSEX",
     )
-    for obs in cleaned_data:
-        obs["DatasetCode"] = "UNSDG_BENFTS_CHILD"
     sspi_clean_api_data.insert_many(cleaned_data)
     sspi_metadata.record_dataset_range(cleaned_data, "UNSDG_BENFTS_CHILD")
     return parse_json(cleaned_data)

--- a/sspi_flask_app/api/core/datasets/unsdg/unsdg_benfts_disab.py
+++ b/sspi_flask_app/api/core/datasets/unsdg/unsdg_benfts_disab.py
@@ -25,8 +25,6 @@ def clean_unsdg_benfts_disab():
     cleaned_data = filter_sdg(
         extracted_data, {"SI_COV_DISAB": "UNSDG_BENFTS_DISAB"}, sex="BOTHSEX",
     )
-    for obs in cleaned_data:
-        obs["DatasetCode"] = "UNSDG_BENFTS_DISAB"
     sspi_clean_api_data.insert_many(cleaned_data)
     sspi_metadata.record_dataset_range(cleaned_data, "UNSDG_BENFTS_DISAB")
     return parse_json(cleaned_data)

--- a/sspi_flask_app/api/core/datasets/unsdg/unsdg_benfts_matnl.py
+++ b/sspi_flask_app/api/core/datasets/unsdg/unsdg_benfts_matnl.py
@@ -25,8 +25,6 @@ def clean_unsdg_benfts_matnl():
     cleaned_data = filter_sdg(
         extracted_data, {"SI_COV_MATNL": "UNSDG_BENFTS_MATNL"},
     )
-    for obs in cleaned_data:
-        obs["DatasetCode"] = "UNSDG_BENFTS_MATNL"
     sspi_clean_api_data.insert_many(cleaned_data)
     sspi_metadata.record_dataset_range(cleaned_data, "UNSDG_BENFTS_MATNL")
     return parse_json(cleaned_data)

--- a/sspi_flask_app/api/core/datasets/unsdg/unsdg_benfts_pensn.py
+++ b/sspi_flask_app/api/core/datasets/unsdg/unsdg_benfts_pensn.py
@@ -25,8 +25,6 @@ def clean_unsdg_benfts_pensn():
     cleaned_data = filter_sdg(
         extracted_data, {"SI_COV_PENSN": "UNSDG_BENFTS_PENSN"}, sex="BOTHSEX",
     )
-    for obs in cleaned_data:
-        obs["DatasetCode"] = "UNSDG_BENFTS_PENSN"
     sspi_clean_api_data.insert_many(cleaned_data)
     sspi_metadata.record_dataset_range(cleaned_data, "UNSDG_BENFTS_PENSN")
     return parse_json(cleaned_data)

--- a/sspi_flask_app/api/core/datasets/unsdg/unsdg_benfts_unemp.py
+++ b/sspi_flask_app/api/core/datasets/unsdg/unsdg_benfts_unemp.py
@@ -25,8 +25,6 @@ def clean_unsdg_benfts_unemp():
     cleaned_data = filter_sdg(
         extracted_data, {"SI_COV_UEMP": "UNSDG_BENFTS_UNEMP"}, sex="BOTHSEX",
     )
-    for obs in cleaned_data:
-        obs["DatasetCode"] = "UNSDG_BENFTS_UNEMP"
     sspi_clean_api_data.insert_many(cleaned_data)
     sspi_metadata.record_dataset_range(cleaned_data, "UNSDG_BENFTS_UNEMP")
     return parse_json(cleaned_data)

--- a/sspi_flask_app/api/core/datasets/unsdg/unsdg_benfts_wrkinj.py
+++ b/sspi_flask_app/api/core/datasets/unsdg/unsdg_benfts_wrkinj.py
@@ -25,8 +25,6 @@ def clean_unsdg_benfts_wrkinj():
     cleaned_data = filter_sdg(
         extracted_data, {"SI_COV_WKINJRY": "UNSDG_BENFTS_WRKINJ"}, sex="BOTHSEX",
     )
-    for obs in cleaned_data:
-        obs["DatasetCode"] = "UNSDG_BENFTS_WRKINJ"
     sspi_clean_api_data.insert_many(cleaned_data)
     sspi_metadata.record_dataset_range(cleaned_data, "UNSDG_BENFTS_WRKINJ")
     return parse_json(cleaned_data)

--- a/sspi_flask_app/api/core/datasets/unsdg/unsdg_labmkt_prog.py
+++ b/sspi_flask_app/api/core/datasets/unsdg/unsdg_labmkt_prog.py
@@ -25,8 +25,6 @@ def clean_unsdg_labmkt_prog():
     cleaned_data = filter_sdg(
         extracted_data, {"SI_COV_LMKT": "UNSDG_LABMKT_PROG"},
     )
-    for obs in cleaned_data:
-        obs["DatasetCode"] = "UNSDG_LABMKT_PROG"
     sspi_clean_api_data.insert_many(cleaned_data)
     sspi_metadata.record_dataset_range(cleaned_data, "UNSDG_LABMKT_PROG")
     return parse_json(cleaned_data)

--- a/sspi_flask_app/api/core/datasets/unsdg/unsdg_nrgint.py
+++ b/sspi_flask_app/api/core/datasets/unsdg/unsdg_nrgint.py
@@ -26,8 +26,6 @@ def clean_unsdg_nrgint():
     filtered_data = filter_sdg(
         extracted_data, idcode_map
     )
-    for obs in filtered_data:
-        obs["DatasetCode"] = "UNSDG_NRGINT"
     sspi_clean_api_data.insert_many(filtered_data)
     sspi_metadata.record_dataset_range(filtered_data, "UNSDG_NRGINT")
     return parse_json(filtered_data)

--- a/sspi_flask_app/api/core/datasets/unsdg/unsdg_socins.py
+++ b/sspi_flask_app/api/core/datasets/unsdg/unsdg_socins.py
@@ -25,8 +25,6 @@ def clean_unsdg_socins():
     cleaned_data = filter_sdg(
         extracted_data, {"SI_COV_SOCINS": "UNSDG_SOCINS"}, sex="BOTHSEX",
     )
-    for obs in cleaned_data:
-        obs["DatasetCode"] = "UNSDG_SOCINS"
     sspi_clean_api_data.insert_many(cleaned_data)
     sspi_metadata.record_dataset_range(cleaned_data, "UNSDG_SOCINS")
     return parse_json(cleaned_data)

--- a/sspi_flask_app/api/core/datasets/unsdg/unsdg_socprt.py
+++ b/sspi_flask_app/api/core/datasets/unsdg/unsdg_socprt.py
@@ -25,8 +25,6 @@ def clean_unsdg_socprt():
     cleaned_data = filter_sdg(
         extracted_data, {"SI_COV_BENFTS": "UNSDG_SOCPRT"}, sex="BOTHSEX",
     )
-    for obs in cleaned_data:
-        obs["DatasetCode"] = "UNSDG_SOCPRT"
     sspi_clean_api_data.insert_many(cleaned_data)
     sspi_metadata.record_dataset_range(cleaned_data, "UNSDG_SOCPRT")
     return parse_json(cleaned_data)

--- a/sspi_flask_app/api/core/save.py
+++ b/sspi_flask_app/api/core/save.py
@@ -44,8 +44,10 @@ def save_all():
     )
 
     def save_iterator(snapshot_directory):
-        for i, database_name in enumerate(sspidb.list_collection_names()):
-            yield f"Saving {database_name} ( {i + 1} / {len(sspidb.list_collection_names())} )\n"
+        database_names = sspidb.list_collection_names()
+        total = len(database_names)
+        for i, database_name in enumerate(database_names):
+            yield f"Saving {database_name} ( {i + 1} / {total} )\n"
             yield from save_database_image(database_name, snapshot_directory)
     return Response(save_iterator(snapshot_directory), mimetype="text/event-stream")
 

--- a/sspi_flask_app/api/core/sspi/ms/fin/fdepth.py
+++ b/sspi_flask_app/api/core/sspi/ms/fin/fdepth.py
@@ -86,7 +86,7 @@ def impute_fdepth():
     )
     imputed_fdepth = []
     for obs in clean_list:
-        if any([inter.get("Imputed", False) for inter in obs["Intermediates"]]):
+        if any(inter.get("Imputed", False) for inter in obs["Intermediates"]):
            imputed_fdepth.append(obs) 
     sspi_imputed_data.insert_many(imputed_fdepth) 
     return parse_json(imputed_fdepth)

--- a/sspi_flask_app/api/core/sspi/ms/neq/ginipt.py
+++ b/sspi_flask_app/api/core/sspi/ms/neq/ginipt.py
@@ -71,7 +71,6 @@ def impute_ginipt():
         "only use ISHRAT data to measure income inequality. We use a simple "
         "linear regression model to predict GINIPT from ISHRAT data."
     )
-    lg, ug = sspi_metadata.get_goalposts("GINIPT")
     for obs in ishrat_data:
         obs["FeatureCode"] = "ISHRAT"
     for obs in prediction_input:

--- a/sspi_flask_app/api/core/sspi/ms/tax/txrdst.py
+++ b/sspi_flask_app/api/core/sspi/ms/tax/txrdst.py
@@ -26,7 +26,6 @@ def compute_txrdst():
     app.logger.info("Running /api/v1/compute/TXRDST")
     sspi_indicator_data.delete_many({"IndicatorCode": "TXRDST"})
     sspi_incomplete_indicator_data.delete_many({"IndicatorCode": "TXRDST"})
-    lg, ug = sspi_metadata.get_goalposts("TXRDST")
     # Fetch clean datasets
     topten_pretax = sspi_clean_api_data.find({"DatasetCode": "WID_NINCSH_PRETAX_P90P100"})
     bfifty_pretax = sspi_clean_api_data.find({"DatasetCode": "WID_NINCSH_PRETAX_P0P50"})

--- a/sspi_flask_app/api/core/sspi/ms/wwb/senior.py
+++ b/sspi_flask_app/api/core/sspi/ms/wwb/senior.py
@@ -113,6 +113,7 @@ def compute_senior():
 
     obs_list = parse_oecd_observations(raw[0]["Raw"][2:][:-1])
     filtered_obs_list = []
+    current_year = datetime.now().year
     for obs in obs_list:
         if not bool(re.match(r'^[A-Z]{3}$', obs["REF_AREA"])):
             continue
@@ -131,7 +132,6 @@ def compute_senior():
             continue
         obs["Value"] = float(obs["Value"])
         obs["Year"] = int(obs["Year"])
-        current_year = datetime.now().year
         if obs["Year"] < 1990 or obs["Year"] > current_year:
             continue
         filtered_obs_list.append(obs)

--- a/sspi_flask_app/api/core/sspi/sus/eco/biodiv.py
+++ b/sspi_flask_app/api/core/sspi/sus/eco/biodiv.py
@@ -62,7 +62,7 @@ def impute_biodiv():
     unsdg_marine = sspi_clean_api_data.find(
         {"DatasetCode": {"$in": ["UNSDG_MARINE"]}}
     )
-    missing_marine = set(sspi_67) - set([m.get("CountryCode", "") for m in unsdg_marine])
+    missing_marine = set(sspi_67) - set(m.get("CountryCode", "") for m in unsdg_marine)
     reference_class_averages = []
     for country in missing_marine:
         reference_class_averages.extend(
@@ -81,7 +81,7 @@ def impute_biodiv():
     unsdg_terrst = sspi_clean_api_data.find(
         {"DatasetCode": {"$in": ["UNSDG_TERRST"]}}
     )
-    missing_terrst = set(sspi_67) - set([m.get("CountryCode", "") for m in unsdg_terrst])
+    missing_terrst = set(sspi_67) - set(m.get("CountryCode", "") for m in unsdg_terrst)
     for country in missing_terrst:
         reference_class_averages.extend(
             impute_reference_class_average(country, 2000, 2023, "Dataset", "UNSDG_TERRST", unsdg_terrst)
@@ -99,7 +99,7 @@ def impute_biodiv():
     unsdg_frshwt = sspi_clean_api_data.find(
         {"DatasetCode": {"$in": ["UNSDG_FRSHWT"]}}
     )
-    missing_frshwt = set(sspi_67) - set([m.get("CountryCode", "") for m in unsdg_frshwt])
+    missing_frshwt = set(sspi_67) - set(m.get("CountryCode", "") for m in unsdg_frshwt)
     for country in missing_frshwt:
         reference_class_averages.extend(
             impute_reference_class_average(country, 2000, 2023, "Dataset", "UNSDG_FRSHWT", unsdg_frshwt)

--- a/sspi_flask_app/api/core/sspi/sus/lnd/watman.py
+++ b/sspi_flask_app/api/core/sspi/sus/lnd/watman.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 from sspi_flask_app.api.core.sspi import compute_bp
 from sspi_flask_app.api.core.sspi import impute_bp
 from flask_login import login_required
@@ -159,10 +161,15 @@ def impute_watman():
     # Countries missing CWUEFF but having WUSEFF (excluding SGP handled separately)
     missing_cwueff_countries = ["AUS", "BGD", "CAN", "CHE", "CHL", "DEU", "ISL", "LVA", "PER", "PHL", "SVN", "THA"]
     
+    # Group WUSEFF observations by country in a single pass for lookup
+    wuseff_by_country = defaultdict(list)
+    for obs in wuseff_data:
+        wuseff_by_country[obs["CountryCode"]].append(obs)
+
     # Create synthetic CWUEFF for each missing country
     synthetic_cwueff_all = []
     for country in missing_cwueff_countries:
-        country_wuseff = [obs for obs in wuseff_data if obs["CountryCode"] == country]
+        country_wuseff = wuseff_by_country.get(country)
         if country_wuseff:
             synthetic_cwueff = create_synthetic_cwueff(country, country_wuseff)
             synthetic_cwueff_all.extend(synthetic_cwueff)

--- a/sspi_flask_app/api/core/sspi/sus/wst/stcons.py
+++ b/sspi_flask_app/api/core/sspi/sus/wst/stcons.py
@@ -58,7 +58,7 @@ def impute_stcons():
 
     # Extract and impute WID_CARBON_TOT_P0P100 data
     wid_p0p100 = sspi_clean_api_data.find({"DatasetCode": "WID_CARBON_TOT_P0P100"})
-    missing_p0p100 = set(sspi_67) - set([d.get("CountryCode", "") for d in wid_p0p100])
+    missing_p0p100 = set(sspi_67) - set(d.get("CountryCode", "") for d in wid_p0p100)
     for country in missing_p0p100:
         reference_class_averages.extend(
             impute_reference_class_average(country, 2000, 2023, "Dataset", "WID_CARBON_TOT_P0P100", wid_p0p100)
@@ -75,7 +75,7 @@ def impute_stcons():
 
     # Extract and impute WID_CARBON_TOT_P90P100 data
     wid_p90p100 = sspi_clean_api_data.find({"DatasetCode": "WID_CARBON_TOT_P90P100"})
-    missing_p90p100 = set(sspi_67) - set([d.get("CountryCode", "") for d in wid_p90p100])
+    missing_p90p100 = set(sspi_67) - set(d.get("CountryCode", "") for d in wid_p90p100)
     for country in missing_p90p100:
         reference_class_averages.extend(
             impute_reference_class_average(country, 2000, 2023, "Dataset", "WID_CARBON_TOT_P90P100", wid_p90p100)
@@ -92,7 +92,7 @@ def impute_stcons():
 
     # Extract and impute FPI_ECOFPT_PER_CAP data
     fpi_ecofpt = sspi_clean_api_data.find({"DatasetCode": "FPI_ECOFPT_PER_CAP"})
-    missing_fpi = set(sspi_67) - set([d.get("CountryCode", "") for d in fpi_ecofpt])
+    missing_fpi = set(sspi_67) - set(d.get("CountryCode", "") for d in fpi_ecofpt)
     for country in missing_fpi:
         reference_class_averages.extend(
             impute_reference_class_average(country, 2000, 2023, "Dataset", "FPI_ECOFPT_PER_CAP", fpi_ecofpt)

--- a/sspi_flask_app/api/datasource/epi.py
+++ b/sspi_flask_app/api/datasource/epi.py
@@ -49,8 +49,8 @@ def parse_epi_csv(raw_csv_string: str, dataset_code: str) -> list[dict]:
     ]
     EPI_long["Year"] = pd.to_numeric(EPI_long["Year"], errors='coerce')
     EPI_long.drop(columns=['YearString'], inplace=True)
-    EPI_long.drop(EPI_long[EPI_long['Value'] < 0].index.tolist(), inplace=True)
-    EPI_long.drop(EPI_long[EPI_long['Value'].isna()].index.tolist(), inplace=True)
+    EPI_long.drop(EPI_long[EPI_long['Value'] < 0].index, inplace=True)
+    EPI_long.drop(EPI_long[EPI_long['Value'].isna()].index, inplace=True)
     EPI_long['DatasetCode'] = dataset_code
     EPI_long['Unit'] = 'Index'
     return json.loads(str(EPI_long.to_json(orient="records")))

--- a/sspi_flask_app/api/datasource/prisonstudies.py
+++ b/sspi_flask_app/api/datasource/prisonstudies.py
@@ -121,26 +121,18 @@ def scrape_stored_pages_for_data():
             "c ", "", regex=True)
         df["Prison Population Rate"] = df["Prison Population Rate"].replace(
             "c ", "", regex=True)
-        if "GBR" in country:
-            df.apply(lambda row: gbr_data.append(
+        # Columns are ("Year", "Prison Population Total", "Prison Population Rate")
+        target = gbr_data if "GBR" in country else final_data
+        for year, total, _rate in df.itertuples(index=False, name=None):
+            target.append(
                 {"IndicatorCode": "PRISON",
-                 "Value": int(row["Prison Population Total"]),
-                 # "WPB Rate": int(row["Prison Population Rate"]),
+                 "Value": int(total),
+                 # "WPB Rate": int(_rate),
                  "IntermediateCode": "PRIPOP",
-                 "Year": int(row["Year"]),
+                 "Year": int(year),
                  "CountryCode": country,
                  "Unit": "People per 100,000",
-                 "Description": "Prison population rate per 100,000 of the national population."}), axis=1)
-        else:
-            df.apply(lambda row: final_data.append(
-                {"IndicatorCode": "PRISON",
-                 "Value": int(row["Prison Population Total"]),
-                 # "WPB Rate": int(row["Prison Population Rate"]),
-                 "IntermediateCode": "PRIPOP",
-                 "Year": int(row["Year"]),
-                 "CountryCode": country,
-                 "Unit": "People per 100,000",
-                 "Description": "Prison population rate per 100,000 of the national population."}), axis=1)
+                 "Description": "Prison population rate per 100,000 of the national population."})
     # combine uk values
     gbr_obs = {}
     for obs in gbr_data:

--- a/sspi_flask_app/api/datasource/taxfoundation.py
+++ b/sspi_flask_app/api/datasource/taxfoundation.py
@@ -37,7 +37,7 @@ def clean_tax_foundation(raw_csv_data, dataset_code, unit, description):
     crptax_melted = crptax_melted.rename(columns={'iso_3':'CountryCode'})
     crptax_melted = crptax_melted.dropna()
     crptax_melted = crptax_melted.sort_values(['CountryCode','Year'],ascending=[True,False]).reset_index(drop=True)
-    crptax_melted["Year"] = crptax_melted["Year"].map(lambda x: int(x))
+    crptax_melted["Year"] = crptax_melted["Year"].astype(int)
     crptax_melted['DatasetCode'] = dataset_code
     crptax_melted['Unit'] = unit
     crptax_melted['Description'] = description

--- a/sspi_flask_app/api/datasource/unfao.py
+++ b/sspi_flask_app/api/datasource/unfao.py
@@ -30,7 +30,7 @@ def format_fao_data_series(raw_data: list, IndicatorCode: str):
     for raw in raw_data:
         if not len(raw["Area Code (ISO3)"]) == 3:
             continue
-        if any([str(i) in raw["Area Code (ISO3)"] for i in range(0, 10)]):
+        if any(str(i) in raw["Area Code (ISO3)"] for i in range(0, 10)):
             continue
         if not raw["Value"]:
             continue

--- a/sspi_flask_app/api/datasource/unsdg.py
+++ b/sspi_flask_app/api/datasource/unsdg.py
@@ -56,11 +56,7 @@ def extract_sdg(raw_sdg_pivot_data):
                 continue
             if isinstance(value, str) and len(value) > 500:
                 continue
-            valid_identifier = any([
-                isinstance(value, str),
-                isinstance(value, float),
-                isinstance(value, int),
-            ])
+            valid_identifier = isinstance(value, (str, float, int))
             if valid_identifier:
                 series_identifiers[field] = value
         country_data = countries.get(numeric=geoAreaCode)
@@ -109,26 +105,26 @@ def filter_sdg(observations: list[dict], idcode_map: dict, rename_map={}, drop_k
         ]
     filtered_list = []
     for obs in observations:
-        if obs["SDGSeriesCode"] not in idcode_map.keys():
+        if obs["SDGSeriesCode"] not in idcode_map:
             continue
         obs["DatasetCode"] = idcode_map[obs["SDGSeriesCode"]]
         drop_obs = False
         for k, v in kwargs.items():
-            if k not in obs.keys():
+            if k not in obs:
                 continue
             list_test = type(v) is list and obs[k] not in v
-            value_test = type(v) in [str, int, float] and obs[k] != v
+            value_test = type(v) in (str, int, float) and obs[k] != v
             if list_test or value_test:
                 drop_obs = True
                 break
         if drop_obs:
             continue
         for k, v in rename_map.items():
-            if k in obs.keys():
+            if k in obs:
                 obs[v] = obs[k]
                 del obs[k]
         for k in drop_keys:
-            if k in obs.keys():
+            if k in obs:
                 del obs[k]
         filtered_list.append(obs)
     return filtered_list

--- a/sspi_flask_app/api/datasource/wid.py
+++ b/sspi_flask_app/api/datasource/wid.py
@@ -69,25 +69,26 @@ def filter_wid_csv(dataset_code:str, csv_string: str, country_code: str, percent
     """
     # Define optimized data types for faster parsing and lower memory usage
     dtype_spec = {
-        'variable': 'category',   # Categorical for repeated variables  
+        'variable': 'category',   # Categorical for repeated variables
         'percentile': 'category', # Categorical for repeated percentile
         'year': 'int16',          # Smaller int type for years (handles 1900-2100+)
         'value': 'float32'        # float32 sufficient for most economic data
     }
-    
+
     # Parse CSV with optimizations - only load needed columns (skip country since each CSV is single-country)
     df = pd.read_csv(
-        StringIO(csv_string), 
+        StringIO(csv_string),
         delimiter=';',
         dtype=dtype_spec,
         usecols=['variable', 'percentile', 'year', 'value']
     )
     log.info(f"Loaded {len(df)} rows from WID CSV data for country {country_code}, variable {variable}, percentile {percentile}, years {years}")
-    
+
     # Chain filters efficiently - each filter reduces dataset size for next operation
     # Order matters: most selective filters first
     log.info(f"Initial dataset size: {len(df)} rows")
-    log.debug(f"Available variables in dataset: {sorted(df['variable'].unique().tolist())}")
+    if log.isEnabledFor(logging.DEBUG):
+        log.debug(f"Available variables in dataset: {sorted(df['variable'].unique().tolist())}")
     filtered = df.query('variable == @variable')
     log.info(f"After variable filter ({variable}): {len(filtered)} rows")
     filtered = filtered.query('percentile == @percentile')

--- a/sspi_flask_app/api/resources/validators.py
+++ b/sspi_flask_app/api/resources/validators.py
@@ -3,6 +3,9 @@ from sspi_flask_app.models.errors import InvalidQueryError
 import re
 
 
+_SAFE_RE = re.compile(r"^[\w\d&-]*$")
+
+
 def validate_data_query(raw_query_input:dict):
     """
     Returns the raw_query_input iff the query is valid. Raises InvalidQueryError if the query is invalid.
@@ -23,8 +26,7 @@ def validate_data_query(raw_query_input:dict):
         """
         if query_string is None:
             return True
-        safe_pattern = r"^[\w\d&-]*$"
-        return bool(re.match(safe_pattern, str(query_string)))
+        return bool(_SAFE_RE.match(str(query_string)))
 
     def validate_query_safety(raw_query_input):
         """

--- a/sspi_flask_app/models/database/sspi_raw_api_data.py
+++ b/sspi_flask_app/models/database/sspi_raw_api_data.py
@@ -141,9 +141,12 @@ class SSPIRawAPIData(MongoWrapper):
             num_fragments = (len(document) + byte_max - 1) // byte_max
             source_info_id = f"{source_info['OrganizationCode']}_{source_info['QueryCode']}"
             fragment_group_id = hashlib.blake2b(document.encode('utf-8')).hexdigest()
+            # kwargs are loop-invariant: apply once. The "Raw" placeholder fixes its
+            # field position before the kwargs keys to match the original ordering.
+            obs["Raw"] = None
+            obs.update(kwargs)
             for i in range(num_fragments):
                 obs["Raw"] = document[byte_max * i:byte_max * i + byte_max]
-                obs.update(kwargs)
                 obs.update({
                     "FragmentGroupID": f"{source_info_id}_{fragment_group_id}",
                     "FragmentNumber": i,


### PR DESCRIPTION
## Summary

Tier 3 of the performance audit (`docs/python-performance-audit.md`) — WARM data-build / ETL / CLI cleanups. All logic-preserving: outputs, ordering, and error semantics unchanged. Produced by parallel agents, then verified centrally.

## Changes (by commit)

- **datasource**: `wid.py` guards a per-call debug log behind `log.isEnabledFor(DEBUG)`; `unsdg.py` `any([isinstance…])`→`isinstance(v, (str,float,int))` + tuple membership + drop redundant `.keys()`; `unfao.py`/`taxfoundation.py`/`epi.py` micro-cleanups; `prisonstudies.py` `df.apply(axis=1)`→`itertuples` (order preserved).
- **unsdg-clean**: remove the redundant `DatasetCode` re-assignment loop in 12 cleaners (`filter_sdg` already sets it). Excludes `unsdg_intrnt`/`unsdg_fampln` (load-bearing) and `unsdg_socassist` (a real bug, fixed in the separate `fix/` PR).
- **compute**: drop duplicate `get_goalposts()` in `txrdst`/`ginipt`; `watman` group-once via `defaultdict`; `senior` hoist `datetime.now()` out of loop; `biodiv`/`stcons`/`fdepth` `set/any([listcomp])`→genexpr.
- **cli/io**: hoist compiled regexes (`cli/utilities.py`, `validators.py`); single dict lookup in `collect.py`; hoist `list_collection_names()` in `save.py`; hoist `obs.update(kwargs)` in `sspi_raw_api_data.py` (doc field order preserved); load `.env` once in the connector.

## Verification

- `pytest tests/unit` — **968 passed, 7 errors** (the 7 are pre-existing security-test `DuplicateKeyError`s, unrelated). Every changed file passes `py_compile`.

## Deliberately skipped
- `epi.py` `str.extract` vectorization (changes no-match error semantics: `AttributeError` vs `NaN`).
- The `api/core/datasets/` dataset-tail micro-fixes (sipri `frozenset`, vdem/itu `str(to_json())`, unfao_crbnav range) — out of the audited datasource scope; a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)