### PR TITLE
refactor: Tier 4 dead-code removal

### DIFF
--- a/sspi_flask_app/api/core/dashboard.py
+++ b/sspi_flask_app/api/core/dashboard.py
@@ -1965,7 +1965,6 @@ def fast_score():
     order_map_literal = {"$literal": indicator_order_map}
     min_year = 2000
     max_year = 2023
-    order_map_literal = {"$literal": indicator_order_map}
     pipeline = [
         {
             "$match": {
@@ -2080,15 +2079,6 @@ def fast_score():
     score_cube = scores.reshape(n_countries, n_years, n_items)
     score_cube_T = np.transpose(score_cube, (2, 0, 1))
     score_list = score_cube_T.reshape(n_items * n_countries, n_years)
-    multi_index = pd.MultiIndex.from_tuples(
-        [(i, c) for i in item_codes for c in country_codes],  # item outer, country inner
-        names=["ItemCode", "CountryCode"]
-    )
-    df = pd.DataFrame(
-        score_list,
-        index=multi_index,
-        columns=np.arange(min_year, max_year + 1)
-    )
     return parse_json(score_list)
 
 

--- a/sspi_flask_app/api/resources/fast_custom_scoring.py
+++ b/sspi_flask_app/api/resources/fast_custom_scoring.py
@@ -73,7 +73,6 @@ def fetch_all_datasets_aggregated(
 
     # Create index mappings for efficient array placement
     country_to_idx = {code: idx for idx, code in enumerate(country_codes)}
-    dataset_to_idx = {code: idx for idx, code in enumerate(dataset_codes)}
 
     logger.info(f"Fetching {len(dataset_codes)} datasets for {n_countries} countries, years {start_year}-{end_year}")
 
@@ -862,126 +861,6 @@ def compute_ranks_vectorized(all_scores: np.ndarray) -> np.ndarray:
             ranks[item_idx, :, year_idx] = rank_values
 
     return ranks
-
-
-def flatten_to_documents(
-    indicator_scores: np.ndarray,
-    aggregated_scores: np.ndarray,
-    indicator_ranks: np.ndarray,
-    aggregated_ranks: np.ndarray,
-    indicator_codes: list[str],
-    item_codes: list[str],
-    country_codes: list[str],
-    start_year: int,
-    metadata: list[dict],
-    imputation_flags: dict[str, np.ndarray] | None = None
-) -> list[dict]:
-    """
-    Convert NumPy arrays to list of score documents for MongoDB.
-
-    Args:
-        indicator_scores: Shape (n_indicators, n_countries, n_years)
-        aggregated_scores: Shape (n_items, n_countries, n_years)
-        indicator_ranks: Shape (n_indicators, n_countries, n_years)
-        aggregated_ranks: Shape (n_items, n_countries, n_years)
-        indicator_codes: Ordered list of indicator codes
-        item_codes: Ordered list of category/pillar/SSPI codes
-        country_codes: Ordered list of country codes
-        start_year: First year in data
-        metadata: Original metadata for item names/types
-        imputation_flags: Optional dict of imputation flag arrays
-
-    Returns:
-        List of score documents ready for bulk insert
-    """
-    # Build metadata lookup tables
-    items_by_code = {item["ItemCode"]: item for item in metadata}
-
-    documents = []
-    n_years = indicator_scores.shape[2]
-
-    # Process indicator scores
-    for ind_idx, ind_code in enumerate(indicator_codes):
-        item = items_by_code.get(ind_code)
-        if not item:
-            logger.warning(f"No metadata found for indicator {ind_code}")
-            continue
-
-        item_name = item.get("ItemName", ind_code)
-
-        for country_idx, country_code in enumerate(country_codes):
-            for year_idx in range(n_years):
-                year = start_year + year_idx
-                score = indicator_scores[ind_idx, country_idx, year_idx]
-                rank = indicator_ranks[ind_idx, country_idx, year_idx]
-
-                # Skip NaN scores
-                if np.isnan(score):
-                    continue
-
-                # Check imputation status if provided
-                imputed = False
-                imputation_method = None
-                if imputation_flags and ind_code in imputation_flags:
-                    imputed = bool(imputation_flags[ind_code][country_idx, year_idx])
-
-                documents.append({
-                    "item_code": ind_code,
-                    "item_name": item_name,
-                    "item_type": "Indicator",
-                    "country_code": country_code,
-                    "year": year,
-                    "score": float(score * 100),  # Convert to 0-100 scale
-                    "rank": int(rank),
-                    "imputed": imputed,
-                    "imputation_method": imputation_method,
-                })
-
-    # Process aggregated scores (categories, pillars, SSPI)
-    for item_idx, item_code in enumerate(item_codes):
-        item = items_by_code.get(item_code)
-
-        # For SSPI root, might not be in metadata by code
-        if not item and item_code == "SSPI":
-            # Find SSPI item by type
-            item = next(
-                (m for m in metadata if m.get("ItemType") == "SSPI"),
-                {"ItemCode": "SSPI", "ItemName": "SSPI", "ItemType": "SSPI"}
-            )
-
-        if not item:
-            logger.warning(f"No metadata found for item {item_code}")
-            continue
-
-        item_name = item.get("ItemName", item_code)
-        item_type = item.get("ItemType", "Unknown")
-
-        for country_idx, country_code in enumerate(country_codes):
-            for year_idx in range(n_years):
-                year = start_year + year_idx
-                score = aggregated_scores[item_idx, country_idx, year_idx]
-                rank = aggregated_ranks[item_idx, country_idx, year_idx]
-
-                # Skip NaN scores
-                if np.isnan(score):
-                    continue
-
-                # Aggregated items inherit imputation from children
-                # For now, mark as not imputed (would need child tracking for accuracy)
-                documents.append({
-                    "item_code": item_code,
-                    "item_name": item_name,
-                    "item_type": item_type,
-                    "country_code": country_code,
-                    "year": year,
-                    "score": float(score * 100),  # Convert to 0-100 scale
-                    "rank": int(rank),
-                    "imputed": False,  # Could be improved to track child imputation
-                    "imputation_method": None,
-                })
-
-    logger.info(f"Flattened {len(documents)} score documents")
-    return documents
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Tier 4 of the performance audit — removal of provably-unused code. Each deletion was verified with a repo-wide `rg` showing the symbol is only defined, never read/called.

## Changes

- `fast_custom_scoring.py`: drop the unused `dataset_to_idx` and the never-called `flatten_to_documents` function.
- `dashboard.py`: drop a duplicate `order_map_literal` build and a dead `multi_index`/`df` construction whose result is never returned or read.

## Notes

- The audit also flagged `customize.py:1452`, but that variable (`all_scored_items`) is now read downstream (the file was refactored since the audit), so it was **left in place**.
- `coverage.py`'s dead `child_details` is handled in the `fix/audit-correctness-bugs` PR (same file as the NameError fix).

## Verification
- `pytest tests/unit` — **968 passed, 7 errors** (pre-existing), `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)