### PR TITLE
fix: correctness bugs surfaced by the performance audit

### DIFF
--- a/sspi_flask_app/api/core/datasets/unsdg/unsdg_socassist.py
+++ b/sspi_flask_app/api/core/datasets/unsdg/unsdg_socassist.py
@@ -25,7 +25,6 @@ def clean_unsdg_socassist():
     cleaned_data = filter_sdg(
         extracted_data, {"SI_COV_SOCAST": "UNSDG_SOCASSIST"}, sex="BOTHSEX",
     )
-    return parse_json(cleaned_data)
     for obs in cleaned_data:
         obs["DatasetCode"] = "UNSDG_SOCASSIST"
     sspi_clean_api_data.insert_many(cleaned_data)

--- a/sspi_flask_app/models/coverage.py
+++ b/sspi_flask_app/models/coverage.py
@@ -3,7 +3,8 @@ from sspi_flask_app.models.database import (
     sspi_indicator_data,
     sspi_imputed_data,
     sspi_item_data,
-    sspi_incomplete_indicator_data
+    sspi_incomplete_indicator_data,
+    sspi_clean_api_data
 )
 
 
@@ -260,8 +261,6 @@ class DataCoverage:
             result_clean = sspi_indicator_data.aggregate(pipeline)
             return result_clean
         child_icodes = [child for child in children]
-        child_details = [sspi_metadata.get_item_detail(child) for child in child_icodes]
-        child_item_field = child_details[0].get("ItemType", "") + "Code"
         if item_field == "IndicatorCode":
             pipeline = [
                 {


### PR DESCRIPTION
## Summary

Real bugs (not performance) surfaced during the audit. Unlike the Tier 1–4 PRs, these intentionally **change behavior** to correct it.

## Fixes

### `unsdg_socassist.py` — cleaner never wrote clean data (the standout)
`clean_unsdg_socassist` had a premature `return parse_json(cleaned_data)` immediately after `filter_sdg`, making the `DatasetCode` tagging, `sspi_clean_api_data.insert_many`, and `record_dataset_range` **unreachable**. So SOCASSIST never had clean data persisted nor a recorded range. Removed the early return so it runs to completion and returns at the end — matching every working UNSDG cleaner (e.g. `unsdg_redlst`).

### `coverage.py` — latent NameError + dead code
- The `IndicatorCode` branch referenced `sspi_clean_api_data`, which was never imported → a latent `NameError` if that branch ran. Added the import.
- Removed a dead `child_details`/`child_item_field` computation (results assigned, never read).

## Investigated but NOT changed (flagged for review)

- **`who_cstunt.py` / `who_fampln.py`** — these have the same early-return shape, but their jq cleaning path has **never executed** (the working WHO siblings use `clean_who_data()` instead), and `fampln`'s jq filter value couldn't be verified without live WHO data. Activating untested code in an automated pass is too risky, so I left them unchanged. **Recommend a deliberate fix with live data.**
- **`load.py`** — the audit flagged `json.loads(request.get_json())` as a double-decode, but the only caller (`connector.SSPIDatabaseConnector.load`, used by push/pull) **double-encodes** the body (`json=json.dumps(...)`), so the server-side `json.loads` is the matching half of a working round-trip. Removing only the server side would break it. A correct fix needs a coordinated client+server change — **left as a documented follow-up.**

## Verification
- `pytest tests/unit` — **968 passed, 7 errors** (pre-existing); no test covered the fixed branches, so counts are unchanged. `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)