### PR TITLE
fix(dashboard): 404 unknown panel/score code before active_schema probe

### DIFF
--- a/sspi_flask_app/api/core/dashboard.py
+++ b/sspi_flask_app/api/core/dashboard.py
@@ -219,12 +219,12 @@ def get_dynamic_score_line_data(item_code):
     """
     Get the dynamic data for the given category code for a line chart
     """
-    indicator_details = sspi_metadata.indicator_details()
-    name_map = {detail["ItemCode"]: detail["ItemName"] for detail in indicator_details}
-    active_schema = sspi_item_data.active_schema(name_map=name_map)
     detail = sspi_metadata.get_item_detail(item_code)
     if "Error" in detail:
         abort(404, description=f"Item code '{item_code}' not found")
+    indicator_details = sspi_metadata.indicator_details()
+    name_map = {detail["ItemCode"]: detail["ItemName"] for detail in indicator_details}
+    active_schema = sspi_item_data.active_schema(name_map=name_map)
     doc_type = detail.get("ItemType", "No Item Type")
     if doc_type == "Indicator":
         item_options = sspi_metadata.indicator_options()


### PR DESCRIPTION
## Problem

`main` CI has been red on a single test since before #899:

```
FAILED tests/integration/test_dashboard_error_handling.py::test_panel_score_unknown_item_code_returns_json_404
  ValueError: No data found for country USA in year 2018.
```

`get_dynamic_score_line_data` (`/api/v1/panel/score/<item_code>`) called `sspi_item_data.active_schema()` **before** validating `item_code`. `active_schema()` probes for baseline `USA`/`2018` scored data and raises `ValueError` when it's absent — true in the thinner CI dataset — so an unknown item code 500'd before reaching the #896 404 guard.

It passes locally only because dev Mongo has USA/2018 data, so `active_schema()` never throws here. The failure reproduces only against CI's dataset.

## Fix

Move the `get_item_detail` lookup + 404 guard ahead of the `active_schema()` call so a bad code returns a content-negotiated 404 regardless of baseline data availability. (The dict-comprehension's `detail` loop variable does not leak in Python 3, so the reorder is safe.)

One file, six-line reorder. This unblocks merging the performance-audit PRs (#900–#903) onto a green `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)