### PR TITLE
chore: ignore .worktrees/ and bump documentation submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ profiler/**
 node_modules
 # CLAUDE.md
 .worktree-ports
+.worktrees/


### PR DESCRIPTION
Repo housekeeping surfaced while cleaning up after the performance-audit merges.

- Ignore `.worktrees/` (where `gh worktree create` puts worktrees) so they never show as untracked noise.
- Bump the `documentation` submodule to `04d6784` ("docs: Renumber API pages and expand contributor guides"), already on its origin/master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)