### PR TITLE
fix(who): write clean data for WHO_CSTUNT and WHO_FAMPLN

### DIFF
--- a/datasets/who/who_fampln/documentation.md
+++ b/datasets/who/who_fampln/documentation.md
@@ -1,8 +1,8 @@
 ---
 DatasetType: Indicator
 DatasetCode: WHO_FAMPLN
-DatasetName: Child Stunting
-Description: Estimated prevalence of stunting in children under 5 (%).
+DatasetName: Demand for Family Planning Satisfied
+Description: Proportion of women of reproductive age (15-49 years) who have their need for family planning satisfied with modern methods (%).
 Source:
   OrganizationCode: WHO
   QueryCode: SDGFPALL 

--- a/sspi_flask_app/api/core/datasets/who/who_cstunt.py
+++ b/sspi_flask_app/api/core/datasets/who/who_cstunt.py
@@ -1,7 +1,7 @@
 ###########################################################
 # Documentation: datasets/who/who_cstunt/documentation.md #
 ###########################################################
-from sspi_flask_app.api.datasource.who import collect_who_data 
+from sspi_flask_app.api.datasource.who import collect_who_data, clean_who_data
 from sspi_flask_app.models.database import (
     sspi_raw_api_data,
     sspi_clean_api_data,
@@ -9,7 +9,6 @@ from sspi_flask_app.models.database import (
 )
 from sspi_flask_app.api.resources.utilities import parse_json
 from sspi_flask_app.api.core.datasets import dataset_collector, dataset_cleaner
-import jq
 
 
 @dataset_collector("WHO_CSTUNT")
@@ -21,27 +20,14 @@ def collect_gho_cstunt(**kwargs):
 def clean_gho_cstunt():
     sspi_clean_api_data.delete_many({"DatasetCode": "WHO_CSTUNT"})
     source_info = sspi_metadata.get_source_info("WHO_CSTUNT")
-    raw_data = sspi_raw_api_data.fetch_raw_data(source_info)[0]["Raw"]
-    # Slice out the relevant data and identifiers (in Dim array)
-    return parse_json(raw_data)
-    first_slice = '.[] | {DatasetCode: "WHO_CSTUNT", Value: .value.numeric, Dim }'
-    first_slice_filter = jq.compile(first_slice)
-    dim_list = first_slice_filter.input(raw_data).all()
-
-    # Reduce/Flatten the Dim array
-    map_reduce = (
-        '.[] |  reduce .Dim[] as $d (.; .[$d.category] = $d.code) | '
-        'select(.WHO == "NUTSTUNTINGPREV")'
+    raw_data = sspi_raw_api_data.fetch_raw_data(source_info)
+    unit = "Percent"
+    description = "Estimated prevalence of stunting in children under 5 (%)."
+    # GHO disaggregates NUTSTUNTINGPREV by SEX; keep the both-sexes total.
+    cleaned_data = clean_who_data(
+        raw_data, "WHO_CSTUNT", unit, description,
+        dimension_values={"Dim1": "SEX_BTSX"},
     )
-    map_reduce_filter = jq.compile(map_reduce)
-    reduced_list = map_reduce_filter.input(dim_list).all()
-    # Remap the keys to the correct names
-    rename_keys = (
-        '.[] | { DatasetCode, CountryCode: .COUNTRY,'
-        'Year: .YEAR, Value, Unit: "Percentage" }'
-    )
-    rename_keys_filter = jq.compile(rename_keys)
-    cleaned_data = rename_keys_filter.input(reduced_list).all()
     sspi_clean_api_data.insert_many(cleaned_data)
     sspi_metadata.record_dataset_range(cleaned_data, "WHO_CSTUNT")
     return parse_json(cleaned_data)

--- a/sspi_flask_app/api/core/datasets/who/who_fampln.py
+++ b/sspi_flask_app/api/core/datasets/who/who_fampln.py
@@ -1,7 +1,7 @@
 ###########################################################
 # Documentation: datasets/who/who_fampln/documentation.md #
 ###########################################################
-from sspi_flask_app.api.datasource.who import collect_who_data 
+from sspi_flask_app.api.datasource.who import collect_who_data, clean_who_data
 from sspi_flask_app.models.database import (
     sspi_raw_api_data,
     sspi_clean_api_data,
@@ -9,7 +9,6 @@ from sspi_flask_app.models.database import (
 )
 from sspi_flask_app.api.resources.utilities import parse_json
 from sspi_flask_app.api.core.datasets import dataset_collector, dataset_cleaner
-import jq
 
 
 @dataset_collector("WHO_FAMPLN")
@@ -21,27 +20,13 @@ def collect_who_fampln(**kwargs):
 def clean_who_fampln():
     sspi_clean_api_data.delete_many({"DatasetCode": "WHO_FAMPLN"})
     source_info = sspi_metadata.get_source_info("WHO_FAMPLN")
-    raw_data = sspi_raw_api_data.fetch_raw_data(source_info)[0]["Raw"]
-    # Slice out the relevant data and identifiers (in Dim array)
-    return parse_json(raw_data)
-    first_slice = '.[] | {DatasetCode: "WHO_FAMPLN", Value: .value.numeric, Dim }'
-    first_slice_filter = jq.compile(first_slice)
-    dim_list = first_slice_filter.input(raw_data).all()
-
-    # Reduce/Flatten the Dim array
-    map_reduce = (
-        '.[] |  reduce .Dim[] as $d (.; .[$d.category] = $d.code) | '
-        'select(.WHO == "NUTSTUNTINGPREV")'
+    raw_data = sspi_raw_api_data.fetch_raw_data(source_info)
+    unit = "Percent"
+    description = (
+        "Proportion of women of reproductive age (15-49 years) who have "
+        "their need for family planning satisfied with modern methods (%)."
     )
-    map_reduce_filter = jq.compile(map_reduce)
-    reduced_list = map_reduce_filter.input(dim_list).all()
-    # Remap the keys to the correct names
-    rename_keys = (
-        '.[] | { DatasetCode, CountryCode: .COUNTRY,'
-        'Year: .YEAR, Value, Unit: "Percentage" }'
-    )
-    rename_keys_filter = jq.compile(rename_keys)
-    cleaned_data = rename_keys_filter.input(reduced_list).all()
+    cleaned_data = clean_who_data(raw_data, "WHO_FAMPLN", unit, description)
     sspi_clean_api_data.insert_many(cleaned_data)
     sspi_metadata.record_dataset_range(cleaned_data, "WHO_FAMPLN")
     return parse_json(cleaned_data)

--- a/sspi_flask_app/api/datasource/who.py
+++ b/sspi_flask_app/api/datasource/who.py
@@ -20,12 +20,27 @@ def collect_who_data(who_indicator_code, **kwargs):
     yield f"Inserted {count} observations into the database."
 
 
-def clean_who_data(raw_data, dataset_code, unit, description):
+def clean_who_data(raw_data, dataset_code, unit, description,
+                   dimension_values=None):
+    """Clean WHO GHO API data into SSPI observation documents.
+
+    dimension_values: optional {field: value} filter used to collapse a
+    disaggregated indicator down to a single series. For example,
+    {"Dim1": "SEX_BTSX"} keeps only the both-sexes total for an indicator
+    that GHO otherwise splits by SEX. Entries that do not match every given
+    filter are skipped. Defaults to no filtering, so undisaggregated
+    indicators are unaffected.
+    """
     cleaned_data_list = []
     for entry in raw_data[0]["Raw"]["value"]:
         if entry["SpatialDimType"] != "COUNTRY":
             continue
         if entry["Value"] == "No data":
+            continue
+        if dimension_values and any(
+            entry.get(field) != value
+            for field, value in dimension_values.items()
+        ):
             continue
         observation = {
             "CountryCode": entry["SpatialDim"],


### PR DESCRIPTION
Both WHO cleaners returned `parse_json(raw_data)` before any cleaning ran, so no clean data was ever written (same shape as the unsdg-socassist bug). The unreachable jq below was written for a now-unused athena endpoint, and `who_fampln`'s was copy-pasted from cstunt (it even filtered `NUTSTUNTINGPREV` and its `documentation.md` mislabelled it "Child Stunting").

## Fix
Rewrite both to use `clean_who_data()` like the working siblings (physpc/dptcov/atbrth), whose collectors already use the matching `ghoapi.azureedge.net` format.

`clean_who_data` alone wasn't enough: `NUTSTUNTINGPREV` is disaggregated by `SEX` (MLE/FMLE/BTSX), producing duplicate `(DatasetCode, CountryCode, Year)` keys that fail validation. So:
- Added an optional, backward-compatible `dimension_values` filter to `clean_who_data` (default = no filter → existing callers unaffected).
- `WHO_CSTUNT` keeps the both-sexes total (`Dim1=SEX_BTSX`).
- `WHO_FAMPLN` is already a single series (female, 15-49); fixed its wrong name/description in the cleaner and `documentation.md` (SDGFPALL = demand for family planning satisfied with modern methods).

## Verified live against the WHO API
- `WHO_CSTUNT`: 4050 rows, 162 countries, 2000-2024, unique per country-year, persisted.
- `WHO_FAMPLN`: 480 rows, 142 countries, 2000-2023, persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)