### PR TITLE
fix(load): single-encode push payload; accept legacy double-encoded body

### DIFF
--- a/connector/SSPIDatabaseConnector.py
+++ b/connector/SSPIDatabaseConnector.py
@@ -1,7 +1,6 @@
 from os import environ, path
 import re
 import ssl
-import json
 from dotenv import load_dotenv
 import requests
 from requests.adapters import HTTPAdapter
@@ -76,7 +75,7 @@ class SSPIDatabaseConnector:
         sesh = self.remote_session if remote else self.local_session
         base_url = self.remote_base if remote else self.local_base
         endpoint = f"{base_url}/api/v1/load/{database_name}"
-        res = sesh.post(endpoint, json=json.dumps(obs_lst))
+        res = sesh.post(endpoint, json=obs_lst)
         return res
 
 

--- a/sspi_flask_app/api/core/load.py
+++ b/sspi_flask_app/api/core/load.py
@@ -28,7 +28,14 @@ def load(database_name):
     is not subject to browser-based CSRF attacks.
     """
     database = lookup_database(database_name)
-    observations_list = json.loads(request.get_json())
+    observations_list = request.get_json()
+    # Back-compat: older/external connectors double-encode the body
+    # (json=json.dumps(obs_lst)), so get_json() yields a JSON string rather
+    # than the list. Decode once more in that case. Current connectors send
+    # the list directly. This shim can be removed once all clients are
+    # confirmed migrated to single-encoding.
+    if isinstance(observations_list, str):
+        observations_list = json.loads(observations_list)
     count = database.insert_many(observations_list)
     message = f"Inserted {count} documents into {database_name}"
     app.logger.info(message)

--- a/tests/unit/adapters/test_sspi_database_connector.py
+++ b/tests/unit/adapters/test_sspi_database_connector.py
@@ -5,3 +5,31 @@ def test_connector_login():
     connector = SSPIDatabaseConnector()
     assert connector.local_token is not None
     assert connector.remote_token is not None
+
+
+def test_load_posts_single_encoded_list(monkeypatch):
+    """load() should send the observation list directly as the JSON body
+    (single-encode), not a json.dumps() string (the old double-encode that
+    the server then had to json.loads a second time)."""
+    connector = SSPIDatabaseConnector()
+    captured = {}
+
+    class _FakeResponse:
+        status_code = 200
+        text = "ok"
+
+    def _fake_post(endpoint, json=None, **kwargs):
+        captured["endpoint"] = endpoint
+        captured["json"] = json
+        return _FakeResponse()
+
+    monkeypatch.setattr(connector.local_session, "post", _fake_post)
+    observations = [
+        {"CountryCode": "USA", "Value": 1},
+        {"CountryCode": "CAN", "Value": 2},
+    ]
+    connector.load(observations, "sspi_clean_api_data", remote=False)
+
+    assert captured["json"] == observations
+    assert not isinstance(captured["json"], str)
+    assert captured["endpoint"].endswith("/api/v1/load/sspi_clean_api_data")


### PR DESCRIPTION
The push connector sent `json=json.dumps(obs_lst)` (double-encoding the body) and the `/load` route did `json.loads(request.get_json())` to undo it.

## Fix
- Connector now sends the list directly (`json=obs_lst`); removed the now-unused `import json`.
- Server decodes once via `request.get_json()`, and **also accepts a JSON-string body** (decodes once more) so any connector/server version skew or external client still double-encoding keeps working. The shim is marked removable once all clients are confirmed migrated.
- Added a connector test pinning the single-encode contract.

`pytest tests/unit/` → 969 passed (incl. the new test); only the 7 pre-existing security `DuplicateKeyError`s remain (local dev-DB dup, green on CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)