### PR TITLE
fix(custom-scoring): Scores-tab chart + scored_hash/NaN-drop/idempotent-store reliability fixes

### DIFF
--- a/sspi_flask_app/api/core/customize.py
+++ b/sspi_flask_app/api/core/customize.py
@@ -462,6 +462,7 @@ def load_configuration(config_id):
             "actions": config.get("actions", []),
             "datasetDetailsMap": all_datasets,
             "has_scores": has_scores,
+            "scored_hash": scored_hash,
             "created_at": config.get("created_at"),
             "updated_at": config.get("updated_at")
         })

--- a/sspi_flask_app/api/resources/custom_scoring.py
+++ b/sspi_flask_app/api/resources/custom_scoring.py
@@ -177,6 +177,57 @@ def identify_empty_datasets(
     )
 
 
+def rebuild_metadata_without_indicators(
+    metadata: list[dict],
+    dropped_codes: set[str]
+) -> list[dict]:
+    """
+    Rebuild metadata after dropping indicators.
+
+    Removes dropped indicators and updates hierarchy references in parent items
+    (Categories) to remove references to dropped indicator codes, so downstream
+    weight normalization renormalizes over the indicators that remain.
+
+    Args:
+        metadata: Original metadata list
+        dropped_codes: Set of indicator codes to drop
+
+    Returns:
+        New metadata list with dropped indicators removed and hierarchy updated
+    """
+    rebuilt = []
+
+    for item in metadata:
+        item_type = item.get("ItemType")
+        item_code = item.get("ItemCode")
+
+        # Skip dropped indicators
+        if item_type == "Indicator" and item_code in dropped_codes:
+            continue
+
+        # For Categories, update IndicatorCodes and Children to remove dropped codes
+        if item_type == "Category":
+            item = dict(item)  # Make a copy to avoid mutating original
+
+            # Update IndicatorCodes
+            if "IndicatorCodes" in item and item["IndicatorCodes"]:
+                item["IndicatorCodes"] = [
+                    code for code in item["IndicatorCodes"]
+                    if code not in dropped_codes
+                ]
+
+            # Update Children
+            if "Children" in item and item["Children"]:
+                item["Children"] = [
+                    code for code in item["Children"]
+                    if code not in dropped_codes
+                ]
+
+        rebuilt.append(item)
+
+    return rebuilt
+
+
 # =============================================================================
 # Dataset Preparation
 # =============================================================================

--- a/sspi_flask_app/api/resources/fast_custom_scoring.py
+++ b/sspi_flask_app/api/resources/fast_custom_scoring.py
@@ -29,6 +29,7 @@ from sspi_flask_app.api.resources.score_function_validator import (
 from sspi_flask_app.api.resources.custom_scoring import (
     DEFAULT_START_YEAR,
     DEFAULT_END_YEAR,
+    rebuild_metadata_without_indicators,
 )
 
 logger = logging.getLogger(__name__)
@@ -997,6 +998,35 @@ def score_custom_configuration_fast(
         start_year,
         end_year
     )
+
+    # Drop indicators that produced no usable score anywhere (NaN across every
+    # country and year). This happens when a score function needs a dataset
+    # that is entirely absent: identify_empty_datasets() only drops an indicator
+    # when ALL of its datasets are empty, so an indicator that needs several
+    # datasets but is missing just one survives that check yet still scores
+    # all-NaN here. Left in place, a single all-NaN indicator poisons the
+    # aggregation matrix multiply (weight * NaN = NaN) and nulls EVERY
+    # category / pillar / SSPI score for every country, so nothing above the
+    # indicator level can be stored. Drop them and renormalize over the
+    # indicators that actually scored, mirroring the pre-scoring empty-dataset
+    # drop.
+    if indicator_scores.size:
+        dead_mask = np.all(np.isnan(indicator_scores), axis=(1, 2))
+        if dead_mask.any():
+            dead_codes = {
+                indicators_to_score[i].get("ItemCode")
+                for i in np.nonzero(dead_mask)[0]
+            }
+            dead_codes.discard(None)
+            logger.warning(
+                f"Dropping {len(dead_codes)} indicator(s) that scored no data "
+                f"(all-NaN across the panel): {', '.join(sorted(dead_codes))}"
+            )
+            indicators_to_score = [
+                ind for ind, dead in zip(indicators_to_score, dead_mask) if not dead
+            ]
+            indicator_scores = indicator_scores[~dead_mask]
+            metadata = rebuild_metadata_without_indicators(metadata, dead_codes)
 
     # Phase 4: Aggregate hierarchy
     if progress_callback:

--- a/sspi_flask_app/api/resources/scoring_tasks.py
+++ b/sspi_flask_app/api/resources/scoring_tasks.py
@@ -33,8 +33,12 @@ from sspi_flask_app.api.resources.metadata_validator import (
 from sspi_flask_app.api.resources.custom_scoring import (
     flatten_scores_for_storage,
     identify_empty_datasets,
+    rebuild_metadata_without_indicators,
     transform_scores_to_line_format,
 )
+
+# Backwards-compatible alias: this helper used to be defined here.
+_rebuild_metadata_without_indicators = rebuild_metadata_without_indicators
 from sspi_flask_app.api.resources.fast_custom_scoring import (
     score_custom_configuration_fast,
 )
@@ -548,60 +552,6 @@ def _abort_if_cancelled(job: ScoringJob) -> bool:
         logger.info(f"Job {job.job_id} cancelled at stage boundary")
         return True
     return False
-
-
-# =============================================================================
-# Metadata Helpers
-# =============================================================================
-
-def _rebuild_metadata_without_indicators(
-    metadata: list[dict],
-    dropped_codes: set[str]
-) -> list[dict]:
-    """
-    Rebuild metadata after dropping indicators.
-
-    Removes dropped indicators and updates hierarchy references in parent items
-    (Categories) to remove references to dropped indicator codes.
-
-    Args:
-        metadata: Original metadata list
-        dropped_codes: Set of indicator codes to drop
-
-    Returns:
-        New metadata list with dropped indicators removed and hierarchy updated
-    """
-    rebuilt = []
-
-    for item in metadata:
-        item_type = item.get("ItemType")
-        item_code = item.get("ItemCode")
-
-        # Skip dropped indicators
-        if item_type == "Indicator" and item_code in dropped_codes:
-            continue
-
-        # For Categories, update IndicatorCodes and Children to remove dropped codes
-        if item_type == "Category":
-            item = dict(item)  # Make a copy to avoid mutating original
-
-            # Update IndicatorCodes
-            if "IndicatorCodes" in item and item["IndicatorCodes"]:
-                item["IndicatorCodes"] = [
-                    code for code in item["IndicatorCodes"]
-                    if code not in dropped_codes
-                ]
-
-            # Update Children
-            if "Children" in item and item["Children"]:
-                item["Children"] = [
-                    code for code in item["Children"]
-                    if code not in dropped_codes
-                ]
-
-        rebuilt.append(item)
-
-    return rebuilt
 
 
 # =============================================================================

--- a/sspi_flask_app/client/templates/customize/custom_visualization.html
+++ b/sspi_flask_app/client/templates/customize/custom_visualization.html
@@ -78,7 +78,23 @@
     </section>
 </article>
 
-<style></style>
+<style>
+.scores-chart-mount {
+    width: 100%;
+    min-height: 480px;
+    margin-top: 1rem;
+}
+
+.viz-inline-error {
+    text-align: center;
+    color: var(--badge-negative-color);
+    padding: 2.5rem 1rem;
+}
+
+.viz-inline-error p {
+    margin-bottom: 1rem;
+}
+</style>
 
 <script>
 window.csrfToken = {{ csrf_token|tojson|safe if csrf_token is defined else '""' }};
@@ -98,6 +114,12 @@ async function fetchWithCSRF(url, options = {}) {
 // Store config data globally for tab access
 let globalConfigData = null;
 let globalResultsData = null;
+// Authoritative cache hash for this config's scored data. Sourced from the
+// stored scored_hash (the FILTERED metadata hash the scorer actually wrote
+// under), so the Scores chart and Sensitivity view both hit the cache even
+// when indicators were dropped for missing data.
+let globalScoredHash = null;
+let scoresChart = null;
 const sensitivityState = { initialized: false, view: null, groups: [] };
 
 document.addEventListener('DOMContentLoaded', async () => {
@@ -134,7 +156,18 @@ document.addEventListener('DOMContentLoaded', async () => {
         // Lazily build the Sensitivity tab on first activation
         setupSensitivityLazyInit();
 
-        if (!resultsData.success || !resultsData.has_results) {
+        // Authoritative scored state + hash come from /load: the backend derives
+        // has_scores from the stored scored_hash, which reflects the FILTERED
+        // metadata that was actually scored. /results recomputes a hash from the
+        // full (unfiltered) metadata, so it can falsely report has_results:false
+        // whenever an indicator was dropped — don't gate on it.
+        globalScoredHash = configData.scored_hash
+            || (resultsData && resultsData.config_hash)
+            || null;
+        const hasScores = configData.has_scores
+            || (resultsData && resultsData.success && resultsData.has_results);
+
+        if (!hasScores || !globalScoredHash) {
             showNoResults();
             return;
         }
@@ -208,10 +241,13 @@ function showError(message) {
 
 function showResults(configData, resultsData) {
     const content = document.getElementById('visualization-content');
-    const stats = resultsData.stats || {};
+    const stats = (resultsData && resultsData.stats) || {};
+    const hasStats = !!(stats.total_results || stats.countries || stats.years || stats.items);
 
-    // Build the visualization content
-    content.innerHTML = `
+    // Stats are best-effort context (sourced from /results, which may be empty
+    // when its full-metadata hash diverges from scored_hash). Only show the
+    // summary when it actually has numbers, so we never display misleading zeros.
+    const summaryHTML = hasStats ? `
         <div class="results-summary">
             <h3>Scoring Results Summary</h3>
             <div class="stats-grid">
@@ -233,167 +269,57 @@ function showResults(configData, resultsData) {
                 </div>
             </div>
         </div>
+    ` : '';
 
-        <div class="chart-section">
-            <div class="item-selector">
-                <label for="item-select">Select Item to Visualize:</label>
-                <select id="item-select">
-                    <option value="">-- Select an item --</option>
-                </select>
-            </div>
-            <div id="chart-container" class="chart-wrapper">
-                <p style="text-align: center; color: var(--low-importance-font-color); padding: 3rem;">
-                    Select an item above to view its chart
-                </p>
-            </div>
-        </div>
+    content.innerHTML = `
+        ${summaryHTML}
+        <div id="scores-chart-mount" class="scores-chart-mount"></div>
     `;
 
-    // Populate item selector from metadata
-    const select = document.getElementById('item-select');
-    const metadata = configData.metadata || [];
-
-    // Group by type
-    const pillars = metadata.filter(m => m.ItemType === 'Pillar');
-    const categories = metadata.filter(m => m.ItemType === 'Category');
-    const indicators = metadata.filter(m => m.ItemType === 'Indicator');
-
-    if (pillars.length > 0) {
-        const group = document.createElement('optgroup');
-        group.label = 'Pillars';
-        pillars.forEach(p => {
-            const opt = document.createElement('option');
-            opt.value = p.ItemCode;
-            opt.textContent = `${p.ItemCode} - ${p.ItemName}`;
-            group.appendChild(opt);
-        });
-        select.appendChild(group);
-    }
-
-    if (categories.length > 0) {
-        const group = document.createElement('optgroup');
-        group.label = 'Categories';
-        categories.forEach(c => {
-            const opt = document.createElement('option');
-            opt.value = c.ItemCode;
-            opt.textContent = `${c.ItemCode} - ${c.ItemName}`;
-            group.appendChild(opt);
-        });
-        select.appendChild(group);
-    }
-
-    if (indicators.length > 0) {
-        const group = document.createElement('optgroup');
-        group.label = 'Indicators';
-        indicators.forEach(i => {
-            const opt = document.createElement('option');
-            opt.value = i.ItemCode;
-            opt.textContent = `${i.ItemCode} - ${i.ItemName}`;
-            group.appendChild(opt);
-        });
-        select.appendChild(group);
-    }
-
-    // Add change listener
-    select.addEventListener('change', (e) => {
-        if (e.target.value) {
-            loadChartData(e.target.value);
-        }
-    });
+    renderScoresChart();
 }
 
-async function loadChartData(itemCode) {
-    const container = document.getElementById('chart-container');
-    container.innerHTML = `
-        <div class="loading-indicator">
-            <div class="spinner"></div>
-            <p>Loading chart data...</p>
-        </div>
-    `;
-
-    try {
-        const response = await fetchWithCSRF(
-            `/api/v1/customize/results/${window.sspiConfigId}/chart-data?item_code=${itemCode}`
-        );
-        const data = await response.json();
-
-        if (!data.success) {
-            container.innerHTML = `
-                <p style="text-align: center; color: var(--low-importance-font-color); padding: 3rem;">
-                    ${data.message || 'No data available for this item'}
-                </p>
-            `;
-            return;
-        }
-
-        renderChart(container, data);
-
-    } catch (error) {
-        console.error('Error loading chart data:', error);
-        container.innerHTML = `
-            <p style="text-align: center; color: var(--badge-negative-color); padding: 3rem;">
-                Error loading chart data. Please try again.
-            </p>
-        `;
+// Mount the live custom panel chart at the SSPI root. The chart auto-fetches
+// /api/v1/customize/panel/score/SSPI?config_hash=...&config_id=... and renders a
+// real line chart over years for every country, plus a built-in item tree so the
+// user can drill into pillars / categories / indicators (each click re-fetches
+// the same custom endpoint). This replaces the old truncated 20-row table.
+function renderScoresChart() {
+    const mount = document.getElementById('scores-chart-mount');
+    if (!mount) {
+        return;
     }
-}
 
-function renderChart(container, data) {
-    // Create a simple table view of the data
-    // A more sophisticated chart can be added later using Chart.js or similar
-    const chartData = data.data;
-    const countries = Object.keys(chartData);
-
-    if (countries.length === 0) {
-        container.innerHTML = `
-            <p style="text-align: center; color: var(--low-importance-font-color); padding: 3rem;">
-                No data available for this item
-            </p>
+    if (typeof CustomSSPIPanelChart === 'undefined') {
+        mount.innerHTML = `
+            <div class="viz-inline-error">
+                <p>The chart component failed to load.</p>
+                <button onclick="window.location.reload()" class="btn-secondary">Reload</button>
+            </div>
         `;
         return;
     }
 
-    // Get all years from the data
-    const allYears = new Set();
-    countries.forEach(country => {
-        chartData[country].forEach(point => allYears.add(point.year));
-    });
-    const years = Array.from(allYears).sort();
+    if (scoresChart && typeof scoresChart.destroy === 'function') {
+        scoresChart.destroy();
+        scoresChart = null;
+    }
 
-    container.innerHTML = `
-        <h4 style="margin: 0 0 1rem 0;">${data.item_name || data.item_code}</h4>
-        <p style="color: var(--low-importance-font-color); margin-bottom: 1rem;">
-            ${data.total_points} data points across ${countries.length} countries
-        </p>
-        <div style="overflow-x: auto;">
-            <table class="data-table" style="width: 100%; border-collapse: collapse;">
-                <thead>
-                    <tr style="background: var(--badge-background-color);">
-                        <th style="padding: 0.5rem; text-align: left; border-bottom: 1px solid var(--border-color);">Country</th>
-                        ${years.map(y => `<th style="padding: 0.5rem; text-align: right; border-bottom: 1px solid var(--border-color);">${y}</th>`).join('')}
-                    </tr>
-                </thead>
-                <tbody>
-                    ${countries.slice(0, 20).map(country => {
-                        const countryData = chartData[country];
-                        const yearMap = {};
-                        countryData.forEach(point => yearMap[point.year] = point.score);
-                        return `
-                            <tr>
-                                <td style="padding: 0.5rem; border-bottom: 1px solid var(--border-color);">${country}</td>
-                                ${years.map(y => `
-                                    <td style="padding: 0.5rem; text-align: right; border-bottom: 1px solid var(--border-color);">
-                                        ${yearMap[y] !== undefined ? yearMap[y].toFixed(2) : '-'}
-                                    </td>
-                                `).join('')}
-                            </tr>
-                        `;
-                    }).join('')}
-                </tbody>
-            </table>
-            ${countries.length > 20 ? `<p style="color: var(--low-importance-font-color); margin-top: 1rem;">Showing first 20 of ${countries.length} countries</p>` : ''}
-        </div>
-    `;
+    try {
+        scoresChart = new CustomSSPIPanelChart(mount, 'SSPI', {
+            configHash: globalScoredHash,
+            configId: window.sspiConfigId,
+            enableComparisonSeries: false
+        });
+    } catch (error) {
+        console.error('Error rendering scores chart:', error);
+        mount.innerHTML = `
+            <div class="viz-inline-error">
+                <p>Unable to render the chart for this configuration.</p>
+                <button onclick="window.location.reload()" class="btn-secondary">Reload</button>
+            </div>
+        `;
+    }
 }
 
 // ========== Sensitivity Tab Functions ==========
@@ -419,7 +345,9 @@ function renderSensitivity() {
     }
 
     // Not scored yet -> reuse the "score this configuration" call to action.
-    if (!globalResultsData || !globalResultsData.success || !globalResultsData.has_results) {
+    // Gate on the authoritative scored_hash (same source as the Scores tab) so a
+    // scored config never falsely shows the not-scored state.
+    if (!globalScoredHash) {
         content.innerHTML = `
             <div class="sensitivity-not-scored">
                 <h3>No Scores Available</h3>
@@ -432,7 +360,7 @@ function renderSensitivity() {
         return;
     }
 
-    const configHash = globalResultsData.config_hash;
+    const configHash = globalScoredHash;
     const metadata = (globalConfigData && globalConfigData.metadata) || [];
     const actions = (globalConfigData && globalConfigData.actions) || [];
     const groups = SensitivityEngine.deriveChangeGroups(actions, metadata);

--- a/sspi_flask_app/models/database/sspi_custom_item_data.py
+++ b/sspi_flask_app/models/database/sspi_custom_item_data.py
@@ -208,7 +208,13 @@ class SSPICustomItemData(MongoWrapper):
         results: list[dict]
     ) -> int:
         """
-        Store complete scoring results for a configuration.
+        Store complete scoring results for a configuration (idempotent replace).
+
+        Any existing rows for ``config_hash`` are cleared before the new set is
+        inserted, so re-scoring the same configuration replaces the cache rather
+        than colliding with the unique ``unique_score_entry`` index. The clear
+        happens only after the replacement set is built and validated, so a
+        validation failure never wipes a good cache.
 
         Args:
             config_hash: SHA-256 hash prefix (32 chars) of canonical config
@@ -243,11 +249,17 @@ class SSPICustomItemData(MongoWrapper):
             self.validate_document_format(doc, i)
             documents.append(doc)
 
-        # Insert all documents
+        # Replace any prior rows for this config_hash so re-scoring is
+        # idempotent and never collides with the unique `unique_score_entry`
+        # index. Done after the replacement set is validated above, so bad
+        # input can't wipe a good cache.
+        self.clear_by_hash(config_hash)
+
+        # Insert all documents (insert_many returns the inserted count)
         try:
-            inserted = self.insert_many(documents)
-            logger.info(f"Stored {len(inserted)} flat score results for config_hash {config_hash[:8]}...")
-            return len(inserted)
+            inserted_count = self.insert_many(documents)
+            logger.info(f"Stored {inserted_count} flat score results for config_hash {config_hash[:8]}...")
+            return inserted_count
         except Exception as e:
             logger.error(f"Failed to store flat score results: {e}")
             raise

--- a/sspi_flask_app/models/database/sspi_custom_panel_data.py
+++ b/sspi_flask_app/models/database/sspi_custom_panel_data.py
@@ -202,7 +202,13 @@ class SSPICustomPanelData(MongoWrapper):
         line_data: list[dict]
     ) -> int:
         """
-        Store line chart data for a configuration.
+        Store line chart data for a configuration (idempotent replace).
+
+        Any existing rows for ``config_hash`` are cleared before the new set is
+        inserted, so re-scoring the same configuration replaces the cache rather
+        than colliding with the unique ``unique_line_entry`` index. The clear
+        happens only after the replacement set is built and validated, so a
+        validation failure never wipes a good cache.
 
         Args:
             config_hash: SHA-256 hash prefix (32 chars) of canonical config
@@ -239,11 +245,17 @@ class SSPICustomPanelData(MongoWrapper):
             self.validate_document_format(doc, i)
             documents.append(doc)
 
-        # Insert all documents
+        # Replace any prior rows for this config_hash so re-scoring is
+        # idempotent and never collides with the unique `unique_line_entry`
+        # index. Done after the replacement set is validated above, so bad
+        # input can't wipe a good cache.
+        self.clear_by_hash(config_hash)
+
+        # Insert all documents (insert_many returns the inserted count)
         try:
-            inserted = self.insert_many(documents)
-            logger.info(f"Stored {len(inserted)} line chart documents for config_hash {config_hash[:8]}...")
-            return len(inserted)
+            inserted_count = self.insert_many(documents)
+            logger.info(f"Stored {inserted_count} line chart documents for config_hash {config_hash[:8]}...")
+            return inserted_count
         except Exception as e:
             logger.error(f"Failed to store line chart data: {e}")
             raise

--- a/tests/unit/models/test_custom_cache_idempotency.py
+++ b/tests/unit/models/test_custom_cache_idempotency.py
@@ -1,0 +1,139 @@
+"""
+Regression tests for the custom-scoring cache write path.
+
+These guard two bugs that produced ~600k duplicate/malformed rows in the
+custom-scoring caches (see fix/custom-scoring-idempotent-store):
+
+1. ``store_*`` returned ``len(int)`` (insert_many already returns a count),
+   raising TypeError *after* a successful insert. The broad caller-side
+   ``except`` swallowed it, so line data was never stored and item rows were
+   re-inserted on every re-score -> duplicate accumulation.
+2. Re-scoring did not clear prior rows first, so a re-store collided with the
+   unique indexes (or, pre-index, silently duplicated). Stores are now an
+   idempotent replace.
+
+A third test pins root cause #2's structural guard: the line cache rejects
+flat (item-shaped) documents.
+"""
+import pytest
+from sspi_flask_app.models.database import sspidb
+from sspi_flask_app.models.database.sspi_custom_item_data import SSPICustomItemData
+from sspi_flask_app.models.database.sspi_custom_panel_data import SSPICustomPanelData
+from sspi_flask_app.models.errors import InvalidDocumentFormatError
+
+
+CONFIG_HASH = "a" * 32  # 32 lowercase hex chars, as the cache key requires
+
+
+@pytest.fixture(scope="function")
+def item_cache():
+    """A SSPICustomItemData wrapper over an isolated test collection with the
+    production unique index built, so a missing clear-before-store regression
+    surfaces as a DuplicateKeyError."""
+    collection = sspidb.sspi_test_custom_item_data
+    collection.delete_many({})
+    wrapper = SSPICustomItemData(collection)
+    wrapper.create_indexes()
+    yield wrapper
+    collection.delete_many({})
+    sspidb.drop_collection(collection)
+
+
+@pytest.fixture(scope="function")
+def panel_cache():
+    """A SSPICustomPanelData wrapper over an isolated test collection with the
+    production unique index built."""
+    collection = sspidb.sspi_test_custom_panel_data
+    collection.delete_many({})
+    wrapper = SSPICustomPanelData(collection)
+    wrapper.create_indexes()
+    yield wrapper
+    collection.delete_many({})
+    sspidb.drop_collection(collection)
+
+
+def _flat_scores():
+    """Two valid flat score docs (store sets config_hash/created_at)."""
+    return [
+        {"item_code": "BIODIV", "item_type": "Indicator", "country_code": "USA", "year": 2020, "score": 0.75},
+        {"item_code": "BIODIV", "item_type": "Indicator", "country_code": "CAN", "year": 2020, "score": 0.50},
+    ]
+
+
+def _line_docs():
+    """Two valid line-chart docs (store sets config_hash/created_at/data)."""
+    return [
+        {"ICode": "SSPI", "IName": "Custom SSPI", "CCode": "USA", "CName": "United States",
+         "CGroup": ["SSPI67"], "years": [2020, 2021], "score": [72.1, 73.5]},
+        {"ICode": "SSPI", "IName": "Custom SSPI", "CCode": "CAN", "CName": "Canada",
+         "CGroup": ["SSPI67"], "years": [2020, 2021], "score": [80.0, 81.2]},
+    ]
+
+
+# =============================================================================
+# Root cause #1a: store_* must return an int count, not raise len(int)
+# =============================================================================
+
+def test_should_return_inserted_count_when_storing_flat_scores(item_cache):
+    count = item_cache.store_scoring_results(CONFIG_HASH, _flat_scores())
+    assert count == 2
+    assert item_cache.count_documents({"config_hash": CONFIG_HASH}) == 2
+
+
+def test_should_return_inserted_count_when_storing_line_data(panel_cache):
+    count = panel_cache.store_line_data(CONFIG_HASH, _line_docs())
+    assert count == 2
+    assert panel_cache.count_documents({"config_hash": CONFIG_HASH}) == 2
+
+
+# =============================================================================
+# Root cause #1b: re-storing the same config_hash is an idempotent replace
+# =============================================================================
+
+def test_should_replace_not_duplicate_when_rescoring_flat_scores(item_cache):
+    item_cache.store_scoring_results(CONFIG_HASH, _flat_scores())
+    # A naive re-store without clear-before-insert would raise DuplicateKeyError
+    # against unique_score_entry; the idempotent replace must succeed.
+    count = item_cache.store_scoring_results(CONFIG_HASH, _flat_scores())
+    assert count == 2
+    assert item_cache.count_documents({"config_hash": CONFIG_HASH}) == 2
+
+
+def test_should_replace_not_duplicate_when_rescoring_line_data(panel_cache):
+    panel_cache.store_line_data(CONFIG_HASH, _line_docs())
+    count = panel_cache.store_line_data(CONFIG_HASH, _line_docs())
+    assert count == 2
+    assert panel_cache.count_documents({"config_hash": CONFIG_HASH}) == 2
+
+
+def test_should_not_evict_other_configs_when_rescoring(item_cache):
+    """The replace must be scoped to its own config_hash."""
+    other_hash = "b" * 32
+    item_cache.store_scoring_results(other_hash, _flat_scores())
+    item_cache.store_scoring_results(CONFIG_HASH, _flat_scores())
+    item_cache.store_scoring_results(CONFIG_HASH, _flat_scores())  # re-score
+    assert item_cache.count_documents({"config_hash": other_hash}) == 2
+
+
+# =============================================================================
+# Clear-after-validate: a bad replacement set must not wipe the good cache
+# =============================================================================
+
+def test_should_preserve_existing_cache_when_replacement_set_is_invalid(item_cache):
+    item_cache.store_scoring_results(CONFIG_HASH, _flat_scores())
+    bad = [{"item_code": "BIODIV", "item_type": "Indicator", "country_code": "USA"}]  # no year/score
+    with pytest.raises(InvalidDocumentFormatError):
+        item_cache.store_scoring_results(CONFIG_HASH, bad)
+    # The original two rows survive because clear happens only after validation.
+    assert item_cache.count_documents({"config_hash": CONFIG_HASH}) == 2
+
+
+# =============================================================================
+# Root cause #2: the line cache rejects flat (item-shaped) documents
+# =============================================================================
+
+def test_should_reject_flat_item_shaped_docs_in_line_cache(panel_cache):
+    flat_shaped = [{"item_code": "BIODIV", "country_code": "USA", "year": 2020, "score": 0.5}]
+    with pytest.raises(InvalidDocumentFormatError):
+        panel_cache.store_line_data(CONFIG_HASH, flat_shaped)
+    assert panel_cache.count_documents({"config_hash": CONFIG_HASH}) == 0

--- a/tests/unit/utilities/test_nan_indicator_drop.py
+++ b/tests/unit/utilities/test_nan_indicator_drop.py
@@ -1,0 +1,111 @@
+"""
+Regression tests for the all-NaN indicator drop in score_custom_configuration_fast.
+
+An indicator whose score function needs a dataset that is entirely absent scores
+NaN across the whole panel. identify_empty_datasets() only drops an indicator
+when ALL of its datasets are empty, so such an indicator can survive that check
+and still score all-NaN. Left in the aggregation, one all-NaN indicator poisons
+the matrix multiply and nulls EVERY category/pillar/SSPI score, so nothing above
+the indicator level gets stored. The engine must drop these post-scoring and
+renormalize over the indicators that actually scored.
+
+These tests mock the Mongo-touching seams so no live database is needed.
+"""
+import numpy as np
+import pytest
+from unittest.mock import patch
+
+from sspi_flask_app.api.resources import fast_custom_scoring as fcs
+from sspi_flask_app.api.resources.custom_scoring import (
+    rebuild_metadata_without_indicators,
+)
+
+
+def _chain_metadata():
+    """SSPI -> one pillar -> one category -> two indicators (GOOD + DEAD)."""
+    return [
+        {"ItemType": "SSPI", "ItemCode": "SSPI", "ItemName": "SSPI",
+         "PillarCodes": ["PIL"], "Children": ["PIL"]},
+        {"ItemType": "Pillar", "ItemCode": "PIL", "ItemName": "Pillar",
+         "CategoryCodes": ["CAT"], "Children": ["CAT"]},
+        {"ItemType": "Category", "ItemCode": "CAT", "ItemName": "Category",
+         "IndicatorCodes": ["GOOD", "DEAD"], "Children": ["GOOD", "DEAD"]},
+        {"ItemType": "Indicator", "ItemCode": "GOOD", "ItemName": "Good",
+         "DatasetCodes": ["DS_GOOD"], "ScoreFunction": "Score = DS_GOOD"},
+        {"ItemType": "Indicator", "ItemCode": "DEAD", "ItemName": "Dead",
+         "DatasetCodes": ["DS_DEAD"], "ScoreFunction": "Score = DS_DEAD"},
+    ]
+
+
+def _run_with_dead_indicator(good_scores, dead_scores):
+    """Run score_custom_configuration_fast with score_indicators_vectorized and
+    the Mongo seams mocked. good_scores/dead_scores are (n_countries, n_years)."""
+    countries = ["AAA", "BBB"]
+    good = np.asarray(good_scores, dtype=float)
+    dead = np.asarray(dead_scores, dtype=float)
+    indicator_scores = np.stack([good, dead])  # (2 indicators, 2 countries, 2 years)
+
+    with patch.object(fcs, "fetch_all_datasets_aggregated",
+                      return_value={"DS_GOOD": np.zeros((2, 2)), "DS_DEAD": np.zeros((2, 2))}), \
+         patch.object(fcs, "impute_dataset_vectorized",
+                      side_effect=lambda arr, mask, neutral_fill=0.5: (arr, np.zeros_like(arr, dtype=bool))), \
+         patch.object(fcs, "score_indicators_vectorized", return_value=indicator_scores), \
+         patch.object(fcs.sspi_metadata, "country_group", return_value=countries):
+        return fcs.score_custom_configuration_fast(
+            _chain_metadata(),
+            country_codes=countries,
+            start_year=2000,
+            end_year=2001,
+        )
+
+
+def test_drops_all_nan_indicator_and_still_aggregates():
+    """A single all-NaN indicator is dropped so SSPI/pillar/category aggregate."""
+    good = [[0.5, 0.6], [0.7, 0.8]]            # GOOD scores for AAA, BBB over 2000-2001
+    dead = [[np.nan, np.nan], [np.nan, np.nan]]  # DEAD scores NaN everywhere
+
+    result = _run_with_dead_indicator(good, dead)
+
+    # The dead indicator contributes no documents...
+    assert not result.get("DEAD"), "all-NaN indicator should produce no score docs"
+    # ...but every aggregate level still has data (the bug nulled all of these).
+    for code in ("CAT", "PIL", "SSPI"):
+        assert result.get(code), f"{code} should have aggregated scores after the drop"
+    assert len(result["SSPI"]) == 4, "2 countries x 2 years of SSPI scores expected"
+
+
+def test_aggregate_equals_surviving_indicator():
+    """With one indicator dropped, the category/SSPI score equals the survivor
+    (weights renormalize over the single remaining indicator -> *100 scale)."""
+    good = [[0.5, 0.6], [0.7, 0.8]]
+    dead = [[np.nan, np.nan], [np.nan, np.nan]]
+
+    result = _run_with_dead_indicator(good, dead)
+
+    sspi_by_cy = {(d["country_code"], d["year"]): d["score"] for d in result["SSPI"]}
+    assert sspi_by_cy[("AAA", 2000)] == pytest.approx(50.0)
+    assert sspi_by_cy[("AAA", 2001)] == pytest.approx(60.0)
+    assert sspi_by_cy[("BBB", 2000)] == pytest.approx(70.0)
+    assert sspi_by_cy[("BBB", 2001)] == pytest.approx(80.0)
+
+
+def test_no_drop_when_all_indicators_score():
+    """When every indicator scores, nothing is dropped and both appear."""
+    good = [[0.5, 0.6], [0.7, 0.8]]
+    other = [[0.3, 0.4], [0.1, 0.2]]
+
+    result = _run_with_dead_indicator(good, other)
+
+    assert result.get("GOOD"), "GOOD should be present"
+    assert result.get("DEAD"), "the non-NaN second indicator should be kept"
+    assert result.get("SSPI"), "SSPI should aggregate both"
+
+
+def test_rebuild_metadata_renormalizes_category_children():
+    """The shared helper removes the indicator and updates parent references."""
+    rebuilt = rebuild_metadata_without_indicators(_chain_metadata(), {"DEAD"})
+    codes = {m["ItemCode"] for m in rebuilt}
+    assert "DEAD" not in codes
+    cat = next(m for m in rebuilt if m["ItemCode"] == "CAT")
+    assert cat["IndicatorCodes"] == ["GOOD"]
+    assert cat["Children"] == ["GOOD"]


### PR DESCRIPTION
Bundles three atomic custom-scoring fixes (all verified this session against a live dev DB).

## Commits
1. **`make cache stores idempotent and return real counts`** (`550d5de40`) — the `store_*` methods now `clear_by_hash` before insert and return the real int count, so re-scoring is an idempotent replace instead of piling up duplicate/malformed cache rows. (Regression tests: `test_custom_cache_idempotency.py`.)
2. **`render real chart on Scores tab via scored_hash`** (`399208f5a`, refs #914) — replaces the truncated 20-row placeholder table with the live `CustomSSPIPanelChart` rooted at SSPI (per-country line chart + drill-down tree). Also fixes "a scored config shows as not scored": the page gated on `/results/<id>`, which recomputes `config_hash` from the **full** metadata, while the scorer drops empty-dataset indicators and stores under the **filtered** `scored_hash`. The page now drives off `/load`'s authoritative `has_scores` + `scored_hash` (newly exposed); Sensitivity tab points at the same hash.
3. **`drop all-NaN indicators so aggregates survive`** (`c1d0f404e`, refs #908 #911) — an indicator whose score function needs an entirely-absent dataset scores all-`NaN`; `identify_empty_datasets` only drops when **all** datasets are empty, so it survives and its `NaN` poisons the aggregation matrix multiply, nulling **every** category/pillar/SSPI score. The engine now drops indicators that scored `NaN` across the whole panel and renormalizes over the survivors (mirroring the empty-dataset drop). Shared `rebuild_metadata_without_indicators` moved to `custom_scoring.py`.

## Verification
- New tests: `tests/unit/utilities/test_nan_indicator_drop.py` (4).
- **50 unit + 33 integration green**, including the oracle-vs-fast parity test (E1) — unaffected, since complete-data configs have no `NaN` and nothing is dropped.
- End-to-end (seeded dev config, headless browser login → visualize): Scores tab renders 1 canvas with 64 country series + 60-node tree, zero console errors, and renders correctly even though `/results` reports `has_results:false`.
- Regression: standard SSPI in a dev DB missing the FORAID/FAMPLN datasets previously produced **0** SSPI/pillar/category rows; now full coverage (43 indicators, 16 categories, 3 pillars, SSPI).

Closes #914.

🤖 Generated with [Claude Code](https://claude.com/claude-code)